### PR TITLE
Update stream.rs

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -53,7 +53,7 @@ impl<'a, I: Clone, S: Span> Stream<'a, I, S> {
                 self.offset += 1;
                 (self.offset - 1, span, Some(out))
             },
-            None => (self.offset, S::new(self.ctx.clone(), self.eoi.clone()..self.eoi.clone()), None),
+            None => (self.offset, S::new(self.ctx.clone(), self.eoi.clone()..(self.eoi.clone() + 1)), None),
         }
     }
 


### PR DESCRIPTION
End of files should be a physical, non zero-width range in the input. Since many error reporting libraries represent zero-width spans in a bad way.