### PR TITLE
Make separated_by leaves the last separator

### DIFF
--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -68,8 +68,8 @@ impl<I: Clone + PartialEq, O, F: Fn(E::Span) -> O, E: Error<I>, const N: usize> 
         &self,
         mut a_errors: Vec<Located<I, P::Error>>,
         a_err: Located<I, P::Error>,
-        parser: P,
-        debugger: &mut D,
+        _parser: P,
+        _debugger: &mut D,
         stream: &mut StreamOf<I, P::Error>,
     ) -> PResult<I, O, P::Error> {
         let pre_state = stream.save();


### PR DESCRIPTION
Hi, Thank you for this great parser combinator library.

I made separated_by leave the last separator token. This has these three changes.

## 1. It may produce a better error message when misplacing trailing comma while not allowed

```rust
just('(')
    .ignore_then(text::int(10).separated_by(just(',')))
    .then_ignore()
    .parse("(1, 2, 3,)")
```

In the above code, ')' causes an error before, but now ',' causes.
However when parsing `(1, 2, 3, illegal_ident)`, I want the error caused by illegal_ident but not)

## 2. It allows whitespace as a separator even if tokens are padded.

```rust
text::ident()
    .separated_by(text::whitespace())
    .map(|token: String| Ident(token))
    .padded()
    .parse("an apple * 3")
```

'3' causes an error before this, but now it succeeds to parse. 

## 3. It may enhance the code readability.