### PR TITLE
Rewind parser

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1134,4 +1134,17 @@ mod tests {
             .chain(just(','));
         assert_eq!(parser.parse("-,-,-,"), Ok(vec!['-', '-', '-', ',']))
     }
+
+    #[test]
+    // TODO: this fails
+    fn reproduce_repeated_with_infix() {
+        let a = just::<_, Simple<char>>('a');
+        let parser = a
+            .clone()
+            .repeated()
+            .then(a.clone().then_ignore(just('-')).then(a))
+            .then_ignore(end());
+
+        assert_eq!(parser.parse("aaa-a"), Ok((vec!['a', 'a'], ('a', 'a'))));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -953,6 +953,25 @@ pub trait Parser<I: Clone, O> {
         }
     }
 
+    /// Make the parser only look ahead and not consume input.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chumsky::prelude::*;
+    /// let terminal_word = text::ident::<_, Simple<char>>()
+    ///     .then_ignore(just('.').lookahead());
+    ///
+    /// assert!(terminal_word.parse("Me too.").is_err());
+    /// assert_eq!(terminal_word.parse("Yes."), Ok("Yes".to_string()));
+    /// ```
+    fn lookahead(self) -> Lookahead<Self>
+    where
+        Self: Sized,
+    {
+        Lookahead(self)
+    }
+
     /// Box the parser, yielding a parser that performs parsing through dynamic dispatch.
     ///
     /// Boxing a parser might be useful for:


### PR DESCRIPTION
Hi, continuously I perfectly enjoying parsing with this amazing crate. Today I introduce `lookahead` combinator.
I don't believe that this should be merged, but this is a little bit convenience for some case. Also, I am not confident on the naming and design of this new combinator.

## Motivation

I want to parse something like this;
```
a b c - d
```
with
```
word
    .repeated()
    .then(word
        .then_ignore(just('-'))
        .then(word))
```

But this fails at `-`.

So I introduce `lookahead` and change the parser like below.

```
word
    .then_ignore(none_of("-".chars()).lookahead())
    .repeated()
    .then(word
        .then_ignore(just('-'))
        .then(word))
```

## Compare to other designs

I choose the one I think it's most fits to chumsky's APIs.

### `word.lookahead(none_of("-".chars()))`

This is like very natural, but always ignores the outputs of the lookahead parser.
In some case, we may want not to ignore, such as infix attribute syntax that have influence to the both side.

### `word.then_ignore(lookahead(none_of("-".chars())))`

This is also natural, and allows us to choose whether ignore the output or not.
However, this is odd in chumsky's conventions.