### PR TITLE
Make clippy happy

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,6 +1,4 @@
 
-use super::*;
-
 mod private {
     pub trait Sealed<T> {}
 
@@ -13,7 +11,8 @@ mod private {
 
 /// A utility trait that facilitates chaining parser outputs together into [`Vec`]s.
 ///
-/// See [`Parser::chain`].
+/// See [`Parser::chain`](super::Parser).
+#[allow(clippy::len_without_is_empty)]
 pub trait Chain<T>: private::Sealed<T> {
     /// The number of items that this chain link consists of.
     fn len(&self) -> usize;

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,4 +1,6 @@
 
+use super::*;
+
 mod private {
     pub trait Sealed<T> {}
 

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,4 +1,3 @@
-use super::*;
 
 mod private {
     pub trait Sealed<T> {}

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -43,7 +43,9 @@ impl<T> Chain<T> for Option<T> {
         self.is_some() as usize
     }
     fn append_to(self, v: &mut Vec<T>) {
-        self.map(|x| v.push(x));
+        if let Some(x) = self {
+            v.push(x);
+        }
     }
 }
 

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -31,7 +31,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, B: Parser<I, O, Error = E>, E: Err
         let a_state = stream.save();
 
         // If the first parser succeeded and produced no secondary errors, don't bother trying the second parser
-        if a_res.0.len() == 0 {
+        if a_res.0.is_empty() {
             if let (a_errors, Ok(a_out)) = a_res {
                 return (a_errors, Ok(a_out));
             }

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -560,14 +560,14 @@ impl<I: Clone, O, U, A: Parser<I, O, Error = E>, B: Parser<I, U, Error = E>, E: 
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
     ) -> PResult<I, Vec<O>, E> {
-        self.at_most.map(|at_most| {
+        if let Some(at_most) = self.at_most {
             assert!(
                 self.at_least <= at_most,
                 "SeparatedBy cannot parse at least {} and at most {}",
                 self.at_least,
                 at_most
-            )
-        });
+            );
+        }
 
         enum State<I, E> {
             Terminated(Located<I, E>),

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -105,7 +105,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, B: Parser<I, O, Error = E>, E: Err
                 a_res.1.map(|(out, alt)| {
                     (
                         out,
-                        merge_alts(alt, b_res.1.map(|(_, alt)| alt).unwrap_or_else(|e| Some(e))),
+                        merge_alts(alt, b_res.1.map(|(_, alt)| alt).unwrap_or_else(Some)),
                     )
                 }),
             )
@@ -116,7 +116,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, B: Parser<I, O, Error = E>, E: Err
                 b_res.1.map(|(out, alt)| {
                     (
                         out,
-                        merge_alts(alt, a_res.1.map(|(_, alt)| alt).unwrap_or_else(|e| Some(e))),
+                        merge_alts(alt, a_res.1.map(|(_, alt)| alt).unwrap_or_else(Some)),
                     )
                 }),
             )

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1067,18 +1067,18 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, L: Into<E::Label> + Clone, E: Erro
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
     ) -> PResult<I, O, E> {
-        let pre_state = stream.save();
+        // let pre_state = stream.save();
         #[allow(deprecated)]
         let (errors, res) = debugger.invoke(&self.0, stream);
         let res = res.map_err(|e| {
-            if e.at > pre_state || true
             /* TODO: Not this? */
-            {
+            /*if e.at > pre_state || true
+            {*/
                 // Only add the label if we committed to this pattern somewhat
                 e.map(|e| e.with_label(self.1.clone().into()))
-            } else {
+            /*} else {
                 e
-            }
+            }*/
         });
         (
             errors

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1072,7 +1072,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, L: Into<E::Label> + Clone, E: Erro
         let (errors, res) = debugger.invoke(&self.0, stream);
         let res = res.map_err(|e| {
             /* TODO: Not this? */
-            /*if e.at > pre_state || true
+            /*if e.at > pre_state
             {*/
                 // Only add the label if we committed to this pattern somewhat
                 e.map(|e| e.with_label(self.1.clone().into()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ where
         note = "You should check that the output types of your parsers are consistent with combinator you're using",
     )
 )]
+#[allow(clippy::type_complexity)]
 pub trait Parser<I: Clone, O> {
     /// The type of errors emitted by this parser.
     type Error: Error<I>; // TODO when default associated types are stable: = Cheap<I>;
@@ -660,7 +661,7 @@ pub trait Parser<I: Clone, O> {
         O: IntoIterator<Item = Inner>,
         Inner: IntoIterator<Item = T>,
     {
-        self.map(|xs| xs.into_iter().map(|xs| xs.into_iter()).flatten().collect())
+        self.map(|xs| xs.into_iter().flat_map(|xs| xs.into_iter()).collect())
     }
 
     /// Parse one thing and then another thing, yielding only the output of the latter.
@@ -1057,6 +1058,7 @@ pub trait Parser<I: Clone, O> {
     /// assert_eq!(uint64.parse("7"), Ok(7));
     /// assert_eq!(uint64.parse("42"), Ok(42));
     /// ```
+    #[allow(clippy::wrong_self_convention)]
     fn from_str<U>(self) -> Map<Self, fn(O) -> Result<U, U::Err>, O>
     where
         Self: Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,8 +120,6 @@ where
     (out, errors.into_iter().map(|e| e.error).collect())
 }
 
-type MapHelper<T, U, R> = Map<T, fn(U) -> R, U>;
-
 /// A trait implemented by parsers.
 ///
 /// Parsers take a stream of tokens of type `I` and attempt to parse them into a value of type `O`. In doing so, they
@@ -635,7 +633,7 @@ pub trait Parser<I: Clone, O> {
     /// assert!(int.parse("-0").is_err());
     /// assert!(int.parse("05").is_err());
     /// ```
-    fn chain<T, U, P>(self, other: P) -> MapHelper<Then<Self, P>, (O, U), Vec<T>>
+    fn chain<T, U, P>(self, other: P) -> Map<Then<Self, P>, fn((O, U)) -> Vec<T>, (O, U)>
     where
         Self: Sized,
         U: Chain<T>,
@@ -1059,7 +1057,7 @@ pub trait Parser<I: Clone, O> {
     /// assert_eq!(uint64.parse("7"), Ok(7));
     /// assert_eq!(uint64.parse("42"), Ok(42));
     /// ```
-    fn from_str<U>(self) -> MapHelper<Self, O, Result<U, U::Err>>
+    fn from_str<U>(self) -> Map<Self, fn(O) -> Result<U, U::Err>, O>
     where
         Self: Sized,
         U: FromStr,
@@ -1092,7 +1090,7 @@ pub trait Parser<I: Clone, O> {
     /// // Does not panic, because the original parser only accepts "true" or "false"
     /// assert!(boolean.parse("42").is_err());
     /// ```
-    fn unwrapped<U, E>(self) -> MapHelper<Self, Result<U, E>, U>
+    fn unwrapped<U, E>(self) -> Map<Self, fn(Result<U, E>) -> U, Result<U, E>>
     where
         Self: Sized + Parser<I, Result<U, E>>,
         E: fmt::Debug,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,8 @@ where
     (out, errors.into_iter().map(|e| e.error).collect())
 }
 
+type MapHelper<T, U, R> = Map<T, fn(U) -> R, U>;
+
 /// A trait implemented by parsers.
 ///
 /// Parsers take a stream of tokens of type `I` and attempt to parse them into a value of type `O`. In doing so, they
@@ -633,7 +635,7 @@ pub trait Parser<I: Clone, O> {
     /// assert!(int.parse("-0").is_err());
     /// assert!(int.parse("05").is_err());
     /// ```
-    fn chain<T, U, P>(self, other: P) -> Map<Then<Self, P>, fn((O, U)) -> Vec<T>, (O, U)>
+    fn chain<T, U, P>(self, other: P) -> MapHelper<Then<Self, P>, (O, U), Vec<T>>
     where
         Self: Sized,
         U: Chain<T>,
@@ -1057,7 +1059,7 @@ pub trait Parser<I: Clone, O> {
     /// assert_eq!(uint64.parse("7"), Ok(7));
     /// assert_eq!(uint64.parse("42"), Ok(42));
     /// ```
-    fn from_str<U>(self) -> Map<Self, fn(O) -> Result<U, U::Err>, O>
+    fn from_str<U>(self) -> MapHelper<Self, O, Result<U, U::Err>>
     where
         Self: Sized,
         U: FromStr,
@@ -1090,7 +1092,7 @@ pub trait Parser<I: Clone, O> {
     /// // Does not panic, because the original parser only accepts "true" or "false"
     /// assert!(boolean.parse("42").is_err());
     /// ```
-    fn unwrapped<U, E>(self) -> Map<Self, fn(Result<U, E>) -> U, Result<U, E>>
+    fn unwrapped<U, E>(self) -> MapHelper<Self, Result<U, E>, U>
     where
         Self: Sized + Parser<I, Result<U, E>>,
         E: fmt::Debug,

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -347,7 +347,7 @@ impl<I: Clone + PartialEq, E: Error<I>> Parser<I, ()> for Seq<I, E> {
 /// assert!(onetwothree.parse([2, 1, 3]).is_err());
 /// ```
 #[deprecated(
-    since = "0.7",
+    since = "0.7.0",
     note = "Use `just` instead: it now works for many sequence-like types!"
 )]
 pub fn seq<I: Clone + PartialEq, Iter: IntoIterator<Item = I>, E>(xs: Iter) -> Seq<I, E> {

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -240,7 +240,7 @@ impl<I: Clone + PartialEq, C: Container<I> + Clone, E: Error<I>> Parser<I, C> fo
                         Vec::new(),
                         Err(Located::at(
                             at,
-                            E::expected_input_found(span, Some(expected.clone()), found),
+                            E::expected_input_found(span, Some(expected), found),
                         )),
                     )
                 }
@@ -373,7 +373,7 @@ impl<I: Clone + PartialEq, C: Container<I>, E: Error<I>> Parser<I, I> for OneOf<
     ) -> PResult<I, I, E> {
         match stream.next() {
             (_, _, Some(tok)) if self.0.get_iter().any(|not| not == tok) => {
-                (Vec::new(), Ok((tok.clone(), None)))
+                (Vec::new(), Ok((tok, None)))
             }
             (at, span, found) => {
                 return (
@@ -473,7 +473,7 @@ impl<I: Clone + PartialEq, C: Container<I>, E: Error<I>> Parser<I, I> for NoneOf
     ) -> PResult<I, I, E> {
         match stream.next() {
             (_, _, Some(tok)) if self.0.get_iter().all(|not| not != tok) => {
-                (Vec::new(), Ok((tok.clone(), None)))
+                (Vec::new(), Ok((tok, None)))
             }
             (at, span, found) => {
                 return (

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -376,7 +376,7 @@ impl<I: Clone + PartialEq, C: Container<I>, E: Error<I>> Parser<I, I> for OneOf<
                 (Vec::new(), Ok((tok, None)))
             }
             (at, span, found) => {
-                return (
+                (
                     Vec::new(),
                     Err(Located::at(
                         at,
@@ -476,7 +476,7 @@ impl<I: Clone + PartialEq, C: Container<I>, E: Error<I>> Parser<I, I> for NoneOf
                 (Vec::new(), Ok((tok, None)))
             }
             (at, span, found) => {
-                return (
+                (
                     Vec::new(),
                     Err(Located::at(
                         at,

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -149,13 +149,13 @@ impl<I: Clone + PartialEq, O, F: Fn(E::Span) -> O, E: Error<I>, const N: usize> 
                     true
                 }
                 (at, span, Some(t)) => {
-                    for i in 0..N {
-                        if t == self.2[i].0 {
-                            balance_others[i] += 1;
-                        } else if t == self.2[i].1 {
-                            balance_others[i] -= 1;
+                    for (balance_other, others) in balance_others.iter_mut().zip(self.2.iter()) {
+                        if t == others.0 {
+                            *balance_other += 1;
+                        } else if t == others.1 {
+                            *balance_other -= 1;
 
-                            if balance_others[i] < 0 && balance == 1 {
+                            if *balance_other < 0 && balance == 1 {
                                 // stream.revert(pre_state);
                                 error.get_or_insert_with(|| {
                                     Located::at(

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -29,6 +29,7 @@ impl<I: Clone + PartialEq, O, E: Error<I>, const N: usize> Strategy<I, O, E>
         stream: &mut StreamOf<I, P::Error>,
     ) -> PResult<I, O, P::Error> {
         loop {
+            #[allow(clippy::blocks_in_if_conditions)]
             if !stream.attempt(|stream| {
                 if stream.next().2.map_or(true, |tok| self.0.contains(&tok)) {
                     (false, false)
@@ -123,6 +124,9 @@ pub struct NestedDelimiters<I, F, const N: usize>(
 impl<I: Clone + PartialEq, O, F: Fn(E::Span) -> O, E: Error<I>, const N: usize> Strategy<I, O, E>
     for NestedDelimiters<I, F, N>
 {
+    // This looks like something weird with clippy, it warns in a weird spot and isn't fixed by
+    // marking it at the spot.
+    #[allow(clippy::blocks_in_if_conditions)]
     fn recover<D: Debugger, P: Parser<I, O, Error = E>>(
         &self,
         mut a_errors: Vec<Located<I, P::Error>>,

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -196,11 +196,11 @@ impl<I: Clone + PartialEq, O, F: Fn(E::Span) -> O, E: Error<I>, const N: usize> 
                     break false;
                 }
             } {
-                if balance == 0 {
-                    break true;
-                } else if balance < 0 {
+                match balance.cmp(&0) {
+                    Ordering::Equal => break true,
                     // The end of a delimited section is not a valid recovery pattern
-                    break false;
+                    Ordering::Less => break false,
+                    Ordering::Greater => (),
                 }
             } else if balance == 0 {
                 // A non-delimiter input before anything else is not a valid recovery pattern

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -24,16 +24,18 @@ enum RecursiveInner<T> {
     Unowned(Weak<T>),
 }
 
+type OnceParser<'a, I, O, E> = OnceCell<Box<dyn Parser<I, O, Error = E> + 'a>>;
+
 /// A parser that can be defined in terms of itself by separating its [declaration](Recursive::declare) from its
 /// [definition](Recursive::define).
 ///
 /// Prefer to use [`recursive()`], which exists as a convenient wrapper around both operations, if possible.
 pub struct Recursive<'a, I, O, E: Error<I>>(
-    RecursiveInner<OnceCell<Box<dyn Parser<I, O, Error = E> + 'a>>>,
+    RecursiveInner<OnceParser<'a, I, O, E>>,
 );
 
 impl<'a, I: Clone, O, E: Error<I>> Recursive<'a, I, O, E> {
-    fn cell(&self) -> Rc<OnceCell<Box<dyn Parser<I, O, Error = E> + 'a>>> {
+    fn cell(&self) -> Rc<OnceParser<'a, I, O, E>> {
         match &self.0 {
             RecursiveInner::Owned(x) => x.clone(),
             RecursiveInner::Unowned(x) => x


### PR DESCRIPTION
Run clippy on the codebase, fixed all but one or two warnings. Did each fix as its own commit, if you want to only pick some I'll scrap the rest, or if you don't want any I can close this. If you want a minimal set, I'd at least bench `redundant_clone` and `needless_range_loop`, as they *might* have an optimization impact. And `deprecated_semver` looks like an actual fix, if a relatively insignificant one.