### PR TITLE
Implement support for `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,15 @@ exclude = [
 ]
 
 [features]
-default = ["ahash"]
+default = ["std"]
+# Integrate with the standard library
+std = []
 # Enable nightly-only features like better compiler diagnostics
 nightly = []
 
 [dependencies]
-# Use `ahash` for maintaining sets of expected inputs
-ahash = { version = "^0.3", optional = true }
+# Due to https://github.com/rust-lang/cargo/issues/1839, this can't be optional
+hashbrown = "0.11"
 
 [dev-dependencies]
 ariadne = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 [features]
 default = ["ahash", "std"]
 # Use `ahash` instead of the standard hasher for maintaining sets of expected inputs
+# (Also used if `std` is disabled)
 ahash = []
 # Integrate with the standard library
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,17 @@ exclude = [
 ]
 
 [features]
-default = ["std"]
+default = ["ahash", "std"]
+# Use `ahash` instead of the standard hasher for maintaining sets of expected inputs
+ahash = []
 # Integrate with the standard library
 std = []
 # Enable nightly-only features like better compiler diagnostics
 nightly = []
 
 [dependencies]
+# Used if `std` is disabled.
+# Provides `ahash` for the corresponding feature as it uses it by default.
 # Due to https://github.com/rust-lang/cargo/issues/1839, this can't be optional
 hashbrown = "0.11"
 

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,11 +1,13 @@
+use alloc::{string::String, vec::Vec};
+
 mod private {
     pub trait Sealed<T> {}
 
     impl<T> Sealed<T> for T {}
     impl<T, A: Sealed<T>> Sealed<T> for (A, T) {}
     impl<T> Sealed<T> for Option<T> {}
-    impl<T> Sealed<T> for Vec<T> {}
-    impl Sealed<char> for String {}
+    impl<T> Sealed<T> for alloc::vec::Vec<T> {}
+    impl Sealed<char> for alloc::string::String {}
 }
 
 /// A utility trait that facilitates chaining parser outputs together into [`Vec`]s.

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -437,7 +437,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, E: Error<I>> Parser<I, Vec<O>> for
                 (mut a_errors, Err(a_err)) if outputs.len() < self.1 => {
                     errors.append(&mut a_errors);
                     (true, ControlFlow::Break((
-                        std::mem::take(&mut errors),
+                        core::mem::take(&mut errors),
                         Err(a_err),
                     )))
                 },
@@ -453,8 +453,8 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, E: Error<I>> Parser<I, Vec<O>> for
                         ),
                     );
                     (false, ControlFlow::Break((
-                        std::mem::take(&mut errors),
-                        Ok((std::mem::take(&mut outputs), alt)),
+                        core::mem::take(&mut errors),
+                        Ok((core::mem::take(&mut outputs), alt)),
                     )))
                 },
             }) {
@@ -773,7 +773,7 @@ impl<I: Clone, O, U, A: Parser<I, O, Error = E>, B: Parser<I, U, Error = E>, E: 
 pub struct Debug<A>(
     pub(crate) A,
     pub(crate) Rc<dyn fmt::Display>,
-    pub(crate) std::panic::Location<'static>,
+    pub(crate) core::panic::Location<'static>,
 );
 
 impl<A: Clone> Clone for Debug<A> {
@@ -1352,6 +1352,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
     use error::Simple;
     use text::TextParser;
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,10 +1,11 @@
 use super::*;
 
-use std::{borrow::Cow, panic::Location};
+use alloc::borrow::Cow;
+use core::panic::Location;
 
 /// Information about a specific parser.
+#[allow(dead_code)]
 pub struct ParserInfo {
-    #[allow(dead_code)]
     name: Cow<'static, str>,
     display: Rc<dyn fmt::Display>,
     location: Location<'static>,
@@ -62,7 +63,10 @@ impl Verbose {
         Self { events: Vec::new() }
     }
 
+    #[allow(unused_variables)]
     fn print_inner(&self, depth: usize) {
+        // a no-op on no_std!
+        #[cfg(feature = "std")]
         for event in &self.events {
             for _ in 0..depth * 4 {
                 print!(" ");

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,10 @@ use std::collections::HashSet;
 #[cfg(not(feature = "std"))]
 use hashbrown::HashSet;
 
+// (ahash + std) => ahash
+// (ahash)       => ahash
+// (std)         => std
+// ()            => ahash
 #[cfg(any(feature = "ahash", not(feature = "std")))]
 type RandomState = hashbrown::hash_map::DefaultHashBuilder;
 #[cfg(all(not(feature = "ahash"), feature = "std"))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,11 @@ use std::collections::HashSet;
 #[cfg(not(feature = "std"))]
 use hashbrown::HashSet;
 
+#[cfg(any(feature = "ahash", not(feature = "std")))]
+type RandomState = hashbrown::hash_map::DefaultHashBuilder;
+#[cfg(all(not(feature = "ahash"), feature = "std"))]
+type RandomState = std::collections::hash_map::RandomState;
+
 /// A trait that describes parser error types.
 ///
 /// If you have a custom error type in your compiler, or your needs are not sufficiently met by [`Simple`], you should
@@ -157,7 +162,7 @@ pub enum SimpleReason<I, S> {
 pub struct Simple<I: Hash + Eq, S = Range<usize>> {
     span: S,
     reason: SimpleReason<I, S>,
-    expected: HashSet<Option<I>>,
+    expected: HashSet<Option<I>, RandomState>,
     found: Option<I>,
     label: Option<&'static str>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(feature = "nightly", feature(rustc_attrs))]
+#![cfg_attr(not(any(doc, feature = "std")), no_std)]
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 #![allow(deprecated)] // TODO: Don't allow this
+
+extern crate alloc;
 
 /// Traits that allow chaining parser outputs together.
 pub mod chain;
@@ -36,16 +39,21 @@ use crate::{
     recovery::*,
 };
 
-use std::{
+use core::{
     cmp::Ordering,
     // TODO: Enable when stable
     //lazy::OnceCell,
     fmt,
     marker::PhantomData,
     ops::Range,
-    rc::Rc,
     str::FromStr,
+};
+use alloc::{
+    boxed::Box,
+    rc::Rc,
+    string::String,
     sync::Arc,
+    vec::Vec,
 };
 
 #[cfg(doc)]
@@ -262,7 +270,7 @@ pub trait Parser<I: Clone, O> {
         Self: Sized,
         T: fmt::Display + 'static,
     {
-        Debug(self, Rc::new(x), *std::panic::Location::caller())
+        Debug(self, Rc::new(x), *core::panic::Location::caller())
     }
 
     /// Map the output of this parser to another value.

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -1,19 +1,19 @@
 use super::*;
 
-use std::rc::{Rc, Weak};
+use alloc::rc::{Rc, Weak};
 
 // TODO: Remove when `OnceCell` is stable
-struct OnceCell<T>(std::cell::RefCell<Option<T>>);
+struct OnceCell<T>(core::cell::RefCell<Option<T>>);
 impl<T> OnceCell<T> {
     pub fn new() -> Self {
-        Self(std::cell::RefCell::new(None))
+        Self(core::cell::RefCell::new(None))
     }
     pub fn set(&self, x: T) -> Result<(), ()> {
         *self.0.try_borrow_mut().map_err(|_| ())? = Some(x);
         Ok(())
     }
-    pub fn get(&self) -> Option<std::cell::Ref<T>> {
-        Some(std::cell::Ref::map(self.0.borrow(), |x| {
+    pub fn get(&self) -> Option<core::cell::Ref<T>> {
+        Some(core::cell::Ref::map(self.0.borrow(), |x| {
             x.as_ref().unwrap()
         }))
     }

--- a/src/span.rs
+++ b/src/span.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 /// A trait that describes a span over a particular range of inputs.
 ///

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,4 +1,5 @@
 use super::*;
+use alloc::vec;
 
 trait StreamExtend<T>: Iterator<Item = T> {
     /// Extend the vector with input. The actual amount can be more or less than `n`, but must be at least 1 (0 implies
@@ -147,10 +148,10 @@ impl<'a, I: Clone, S: Span + 'a> BoxStream<'a, I, S> {
         iter: Iter,
         mut flatten: F,
     ) -> Self {
-        let mut v: Vec<std::collections::VecDeque<(P, S)>> = vec![iter.collect()];
+        let mut v: Vec<alloc::collections::VecDeque<(P, S)>> = vec![iter.collect()];
         Self::from_iter(
             eoi,
-            Box::new(std::iter::from_fn(move || loop {
+            Box::new(core::iter::from_fn(move || loop {
                 if let Some(many) = v.last_mut() {
                     match many.pop_front().map(&mut flatten) {
                         Some(Flat::Single(input)) => break Some(input),
@@ -290,7 +291,7 @@ impl<'a, T: Clone + 'a, const N: usize> From<[T; N]>
         Self::from_iter(
             len..len + 1,
             Box::new(
-                std::array::IntoIter::new(s)
+                core::array::IntoIter::new(s)
                     .enumerate()
                     .map(|(i, x)| (x, i..i + 1)),
             ),


### PR DESCRIPTION
I added a `std` feature to support building with `no_std`.

If enabled, it implements the `Error` trait and uses `std`'s `HashSet`.
Otherwise, it doesn't implement `Error` and uses `hashbrown`'s `HashSet`.

However, there are a few details I'd like to hear your opinion on if I need to make some changes.

* `no_std` is disabled in documentation.
* Because of rust-lang/cargo#1839, the dependency on `hashbrown` can't be optional. It could probably be if there was a `no_std` feature instead, but [according to the feature reference in the Cargo book](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification), features should be additive, and a `std` feature should be used over a `no_std` one.
* I looked into `hashbrown` and found that it uses `ahash` by default (through a default feature), so I removed the direct dependency on it and used it through `hashbrown`. This may be undesirable.
* The `Verbose` struct in the `debug` module currently uses the `print!` macros. Since those do not exist in a `no_std` environment, the function that uses them was changed to be a no-op when `std` is disabled.

(Closes #38)
