### PR TITLE
Replace error `Vec` with a linked list of slab `Vec`s

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -162,7 +162,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, E: Error<I>> Parser<I, Option<O>> 
             debugger.invoke(&self.0, stream)
         }) {
             (errors, Ok((out, alt))) => (errors, Ok((Some(out), alt))),
-            (_, Err(err)) => (Vec::new(), Ok((None, Some(err)))),
+            (_, Err(err)) => (FlatList::new(), Ok((None, Some(err)))),
         }
     }
 
@@ -435,7 +435,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, E: Error<I>> Parser<I, Vec<O>> for
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
     ) -> PResult<I, Vec<O>, E> {
-        let mut errors = Vec::new();
+        let mut errors = FlatList::new();
         let mut outputs = Vec::new();
         let mut alt = None;
         let mut old_offset = None;
@@ -698,7 +698,7 @@ impl<I: Clone, O, U, A: Parser<I, O, Error = E>, B: Parser<I, U, Error = E>, E: 
             stream: &mut StreamOf<I, E>,
             debugger: &mut D,
             outputs: &mut Vec<O>,
-            errors: &mut Vec<Located<I, E>>,
+            errors: &mut FlatList<Located<I, E>>,
             alt: Option<Located<I, E>>,
         ) -> (State<I, E>, Option<Located<I, E>>) {
             match stream.try_parse(|stream| {
@@ -718,7 +718,7 @@ impl<I: Clone, O, U, A: Parser<I, O, Error = E>, B: Parser<I, U, Error = E>, E: 
         }
 
         let mut outputs = Vec::new();
-        let mut errors = Vec::new();
+        let mut errors = FlatList::new();
         let mut alt = None;
 
         if self.allow_leading {

--- a/src/flatlist.rs
+++ b/src/flatlist.rs
@@ -1,0 +1,323 @@
+//! Data structures to more efficiently aggregate the results of multiple parsers.
+
+use std::{
+    collections::LinkedList,
+    iter::{FromIterator, FusedIterator},
+};
+
+/// Segmented list that internally stores sequences of multiple `T`s as they are added.
+///
+/// Addition of elements and element sequences behaves like a linked list and is O(1).
+/// Using [`iter`](FlatList::iter), you can iterate over all elements as if they were stored in one, contiguous list.
+#[derive(Debug, Clone)]
+#[repr(transparent)]
+pub struct FlatList<T> {
+    inner: LinkedList<Vec<T>>,
+}
+
+impl<T> Default for FlatList<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> FlatList<T> {
+    /// Constructs a new, empty `FlatList<T>`.
+    pub const fn new() -> Self {
+        Self {
+            inner: LinkedList::new(),
+        }
+    }
+
+    /// Adds a single element to `self`.
+    #[inline(always)]
+    pub fn push(&mut self, t: T) {
+        if self.inner.is_empty() {
+            self.inner.push_back(Vec::with_capacity(8));
+        }
+        unsafe { self.inner.back_mut().unwrap_unchecked().push(t) };
+    }
+
+    /// Adds a sequence of `T`s to the list.
+    #[inline(always)]
+    pub fn add_sequence(&mut self, seq: Vec<T>) {
+        if seq.is_empty() {
+            return;
+        }
+        self.inner.push_back(seq);
+    }
+
+    /// Moves all the elements of `other` to the end of `self`, leaving `other` empty.
+    ///
+    /// This operation should compute in O(1) time and O(1) memory.
+    #[inline(always)]
+    pub fn append(&mut self, other: &mut FlatList<T>) {
+        self.inner.append(&mut other.inner);
+    }
+
+    /// Returns the last element in the list, or `None` if the list is empty.
+    #[inline(always)]
+    pub fn last(&self) -> Option<&T> {
+        // Note: `inner` cannot contain empty sequences, so the last sequence always contains at least one element
+        self.inner.back().and_then(|seq| seq.last())
+    }
+
+    /// Returns a mutable reference the last element in the list, or `None` if the list is empty.
+    #[inline(always)]
+    pub fn last_mut(&mut self) -> Option<&mut T> {
+        // Note: `inner` cannot contain empty sequences, so the last sequence always contains at least one element
+        self.inner.back_mut().and_then(|seq| seq.last_mut())
+    }
+
+    /// Returns the number of elements in the list.
+    pub fn len(&self) -> usize {
+        self.inner.iter().map(|seq| seq.len()).sum()
+    }
+
+    /// Returns `true` if the list contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty() || self.len() == 0
+    }
+
+    /// Returns an immutable iterator over all elements in `self`.
+    #[inline(always)]
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter::new(self)
+    }
+}
+
+impl<'list, T: 'list> IntoIterator for &'list FlatList<T> {
+    type Item = &'list T;
+    type IntoIter = Iter<'list, T>;
+
+    /// Returns an immutable iterator over all elements in `self`.
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<T> IntoIterator for FlatList<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    /// Returns an owned iterator over all elements in `self`.
+    #[inline(always)]
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter::new(self)
+    }
+}
+
+impl<T> Extend<T> for FlatList<T> {
+    #[cfg(feature = "nightly")]
+    #[inline(always)]
+    fn extend_one(&mut self, item: T) {
+        self.push(item);
+    }
+
+    #[inline(always)]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.add_sequence(iter.into_iter().collect())
+    }
+}
+
+impl<T> FromIterator<T> for FlatList<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut this = Self::new();
+        this.extend(iter);
+        this
+    }
+}
+
+/// Immutable flat list iterator.
+/// Will iterate over the flat list as a single sequence of `T`s.
+#[derive(Debug)]
+pub struct Iter<'list, T: 'list> {
+    list_iter: std::collections::linked_list::Iter<'list, Vec<T>>,
+    current_segment: Option<std::slice::Iter<'list, T>>,
+    done: bool,
+}
+
+impl<'list, T: 'list> Iter<'list, T> {
+    fn new(list: &'list FlatList<T>) -> Self {
+        // make sure that if we start with the first segment of `inner` already the list iterator is advanced and we don't get that segment twice
+        let mut list_iter = list.inner.iter();
+        let mut done = false;
+        let current_segment = match list_iter.next().map(|v| v.iter()) {
+            iter @ Some(_) => iter,
+            None => {
+                done = true;
+                None
+            }
+        };
+        Self {
+            list_iter,
+            current_segment,
+            done,
+        }
+    }
+}
+
+impl<'list, T: 'list> Iterator for Iter<'list, T> {
+    type Item = &'list T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        loop {
+            if let Some(seq) = self.current_segment.as_mut() {
+                match seq.next() {
+                    Some(elem) => return Some(elem),
+                    None => match self.list_iter.next() {
+                        // N.B. `LinkedList`'s `Iter` is a `FusedIterator`
+                        Some(seq) => self.current_segment = Some(seq.iter()),
+                        None => {
+                            self.done = true;
+                            return None;
+                        }
+                    },
+                }
+            }
+        }
+    }
+}
+
+impl<'list, T: 'list> FusedIterator for Iter<'list, T> {}
+
+/// Owned flat list iterator.
+/// Will iterate over the flat list as a single sequence of `T`s.
+#[derive(Debug)]
+pub struct IntoIter<T> {
+    list_iter: std::collections::linked_list::IntoIter<Vec<T>>,
+    current_segment: Option<std::vec::IntoIter<T>>,
+    done: bool,
+}
+
+impl<T> IntoIter<T> {
+    fn new(list: FlatList<T>) -> Self {
+        // make sure that if we start with the first segment of `inner` already the list iterator is advanced and we don't get that segment twice
+        let mut list_iter = list.inner.into_iter();
+        let mut done = false;
+        let current_segment = match list_iter.next().map(|v| v.into_iter()) {
+            iter @ Some(_) => iter,
+            None => {
+                done = true;
+                None
+            }
+        };
+        Self {
+            list_iter,
+            current_segment,
+            done,
+        }
+    }
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        loop {
+            if let Some(seq) = self.current_segment.as_mut() {
+                match seq.next() {
+                    Some(elem) => return Some(elem),
+                    None => match self.list_iter.next() {
+                        // N.B. `LinkedList`'s `IntoIter` is a `FusedIterator`
+                        Some(seq) => self.current_segment = Some(seq.into_iter()),
+                        None => {
+                            self.done = true;
+                            return None;
+                        }
+                    },
+                }
+            }
+        }
+    }
+}
+
+impl<T> FusedIterator for IntoIter<T> {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn iter() {
+        let mut list = FlatList::new();
+        list.add_sequence(vec![1, 2, 3, 4]);
+        list.push(5);
+        list.add_sequence(vec![6, 7]);
+        list.push(8);
+        list.push(9);
+        let collected: Vec<_> = list.iter().copied().collect();
+        let expected: Vec<_> = (1..=9).collect();
+        assert_eq!(collected, expected);
+    }
+
+    #[test]
+    fn iter_only_singles() {
+        let mut list = FlatList::new();
+        list.push(5);
+        list.push(8);
+        list.push(9);
+        let collected: Vec<_> = list.iter().copied().collect();
+        assert_eq!(collected, vec![5, 8, 9]);
+    }
+
+    #[test]
+    fn iter_empty() {
+        let list = FlatList::<usize>::new();
+        let collected: Vec<_> = list.iter().copied().collect();
+        assert_eq!(collected, vec![]);
+    }
+
+    #[test]
+    fn into_iter() {
+        let mut list = FlatList::new();
+        list.add_sequence(vec![1, 2, 3, 4]);
+        list.push(5);
+        list.add_sequence(vec![6, 7]);
+        list.push(8);
+        list.push(9);
+        let collected: Vec<_> = list.into_iter().collect();
+        let expected: Vec<_> = (1..=9).collect();
+        assert_eq!(collected, expected);
+    }
+
+    #[test]
+    fn into_iter_only_singles() {
+        let mut list = FlatList::new();
+        list.push(5);
+        list.push(8);
+        list.push(9);
+        let collected: Vec<_> = list.into_iter().collect();
+        assert_eq!(collected, vec![5, 8, 9]);
+    }
+
+    #[test]
+    fn into_iter_empty() {
+        let list = FlatList::<usize>::new();
+        let collected: Vec<_> = list.into_iter().collect();
+        assert_eq!(collected, vec![]);
+    }
+
+    #[test]
+    fn append() {
+        let mut list = FlatList::new();
+        list.add_sequence(vec![1, 2, 3, 4]);
+        list.push(5);
+        list.add_sequence(vec![6, 7]);
+        list.push(8);
+        list.push(9);
+        let mut list2 = FlatList::new();
+        list2.append(&mut list);
+        let collected: Vec<_> = list2.into_iter().collect();
+        let expected: Vec<_> = (1..=9).collect();
+        assert_eq!(collected, expected);
+        assert!(list.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod chain;
 pub mod combinator;
 pub mod debug;
 pub mod error;
+pub mod flatlist;
 pub mod primitive;
 pub mod recovery;
 pub mod recursive;
@@ -23,6 +24,7 @@ use crate::{
     combinator::*,
     debug::*,
     error::{merge_alts, Located},
+    flatlist::FlatList,
     primitive::*,
     recovery::*,
 };
@@ -79,7 +81,7 @@ enum ControlFlow<C, B> {
 // ([...], Err(err)) => parsing failed, recovery failed, and one or more errors were produced
 // TODO: Change `alt_err` from `Option<Located<I, E>>` to `Vec<Located<I, E>>`
 type PResult<I, O, E> = (
-    Vec<Located<I, E>>,
+    FlatList<Located<I, E>>,
     Result<(O, Option<Located<I, E>>), Located<I, E>>,
 );
 
@@ -951,6 +953,7 @@ pub trait Parser<I: Clone, O> {
     /// // This input has two syntax errors...
     /// let (ast, errors) = expr.parse_recovery("[[1, two], [3, four]]");
     /// // ...and error recovery allows us to catch both of them!
+    /// dbg!(&errors);
     /// assert_eq!(errors.len(), 2);
     /// // Additionally, the AST we get back still has useful information.
     /// assert_eq!(ast, Some(Expr::List(vec![Expr::Error, Expr::Error])));

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -76,9 +76,9 @@ impl<I: Clone, E: Error<I>> Parser<I, ()> for End<E> {
         stream: &mut StreamOf<I, E>,
     ) -> PResult<I, (), E> {
         match stream.next() {
-            (_, _, None) => (Vec::new(), Ok(((), None))),
+            (_, _, None) => (FlatList::new(), Ok(((), None))),
             (at, span, found) => (
-                Vec::new(),
+                FlatList::new(),
                 Err(Located::at(
                     at,
                     E::expected_input_found(span, Some(None), found),
@@ -269,7 +269,7 @@ impl<I: Clone + PartialEq, C: Container<I> + Clone, E: Error<I>> Parser<I, C> fo
                 (_, _, Some(tok)) if tok == expected => {}
                 (at, span, found) => {
                     return (
-                        Vec::new(),
+                        FlatList::new(),
                         Err(Located::at(
                             at,
                             E::expected_input_found(span, Some(Some(expected)), found),
@@ -279,7 +279,7 @@ impl<I: Clone + PartialEq, C: Container<I> + Clone, E: Error<I>> Parser<I, C> fo
             }
         }
 
-        (Vec::new(), Ok((self.0.clone(), None)))
+        (FlatList::new(), Ok((self.0.clone(), None)))
     }
 
     fn parse_inner_verbose(&self, d: &mut Verbose, s: &mut StreamOf<I, E>) -> PResult<I, C, E> {
@@ -335,7 +335,7 @@ impl<I: Clone + PartialEq, E: Error<I>> Parser<I, ()> for Seq<I, E> {
                 (_, _, Some(tok)) if &tok == expected => {}
                 (at, span, found) => {
                     return (
-                        Vec::new(),
+                        FlatList::new(),
                         Err(Located::at(
                             at,
                             E::expected_input_found(span, Some(Some(expected.clone())), found),
@@ -345,7 +345,7 @@ impl<I: Clone + PartialEq, E: Error<I>> Parser<I, ()> for Seq<I, E> {
             }
         }
 
-        (Vec::new(), Ok(((), None)))
+        (FlatList::new(), Ok(((), None)))
     }
 
     fn parse_inner_verbose(&self, d: &mut Verbose, s: &mut StreamOf<I, E>) -> PResult<I, (), E> {
@@ -405,10 +405,10 @@ impl<I: Clone + PartialEq, C: Container<I>, E: Error<I>> Parser<I, I> for OneOf<
     ) -> PResult<I, I, E> {
         match stream.next() {
             (_, _, Some(tok)) if self.0.get_iter().any(|not| not == tok) => {
-                (Vec::new(), Ok((tok, None)))
+                (FlatList::new(), Ok((tok, None)))
             }
             (at, span, found) => (
-                Vec::new(),
+                FlatList::new(),
                 Err(Located::at(
                     at,
                     E::expected_input_found(span, self.0.get_iter().map(Some), found),
@@ -464,7 +464,7 @@ impl<I: Clone, E: Error<I>> Parser<I, ()> for Empty<E> {
         _debugger: &mut D,
         _: &mut StreamOf<I, E>,
     ) -> PResult<I, (), E> {
-        (Vec::new(), Ok(((), None)))
+        (FlatList::new(), Ok(((), None)))
     }
 
     fn parse_inner_verbose(&self, d: &mut Verbose, s: &mut StreamOf<I, E>) -> PResult<I, (), E> {
@@ -503,10 +503,10 @@ impl<I: Clone + PartialEq, C: Container<I>, E: Error<I>> Parser<I, I> for NoneOf
     ) -> PResult<I, I, E> {
         match stream.next() {
             (_, _, Some(tok)) if self.0.get_iter().all(|not| not != tok) => {
-                (Vec::new(), Ok((tok, None)))
+                (FlatList::new(), Ok((tok, None)))
             }
             (at, span, found) => (
-                Vec::new(),
+                FlatList::new(),
                 Err(Located::at(
                     at,
                     E::expected_input_found(span, Vec::new(), found),
@@ -661,9 +661,9 @@ impl<I: Clone, F: Fn(&I) -> bool, E: Error<I>> Parser<I, I> for Filter<F, E> {
         stream: &mut StreamOf<I, E>,
     ) -> PResult<I, I, E> {
         match stream.next() {
-            (_, _, Some(tok)) if (self.0)(&tok) => (Vec::new(), Ok((tok, None))),
+            (_, _, Some(tok)) if (self.0)(&tok) => (FlatList::new(), Ok((tok, None))),
             (at, span, found) => (
-                Vec::new(),
+                FlatList::new(),
                 Err(Located::at(
                     at,
                     E::expected_input_found(span, Vec::new(), found),
@@ -722,10 +722,10 @@ impl<I: Clone, O, F: Fn(E::Span, I) -> Result<O, E>, E: Error<I>> Parser<I, O> f
     ) -> PResult<I, O, E> {
         let (at, span, tok) = stream.next();
         match tok.map(|tok| (self.0)(span.clone(), tok)) {
-            Some(Ok(tok)) => (Vec::new(), Ok((tok, None))),
-            Some(Err(err)) => (Vec::new(), Err(Located::at(at, err))),
+            Some(Ok(tok)) => (FlatList::new(), Ok((tok, None))),
+            Some(Err(err)) => (FlatList::new(), Err(Located::at(at, err))),
             None => (
-                Vec::new(),
+                FlatList::new(),
                 Err(Located::at(
                     at,
                     E::expected_input_found(span, Vec::new(), None),
@@ -898,7 +898,7 @@ macro_rules! impl_for_tuple {
                         },
                     };
                 )*
-                (Vec::new(), Err(alt.unwrap()))
+                (FlatList::new(), Err(alt.unwrap()))
             }
 
             fn parse_inner_verbose(

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -9,7 +9,7 @@ pub trait Strategy<I: Clone, O, E: Error<I>> {
     /// Recover from a parsing failure.
     fn recover<D: Debugger, P: Parser<I, O, Error = E>>(
         &self,
-        recovered_errors: Vec<Located<I, P::Error>>,
+        recovered_errors: FlatList<Located<I, P::Error>>,
         fatal_error: Located<I, P::Error>,
         parser: P,
         debugger: &mut D,
@@ -26,7 +26,7 @@ impl<I: Clone + PartialEq, O, E: Error<I>, const N: usize> Strategy<I, O, E>
 {
     fn recover<D: Debugger, P: Parser<I, O, Error = E>>(
         &self,
-        a_errors: Vec<Located<I, P::Error>>,
+        a_errors: FlatList<Located<I, P::Error>>,
         a_err: Located<I, P::Error>,
         parser: P,
         debugger: &mut D,
@@ -71,7 +71,7 @@ impl<I: Clone + PartialEq, O, F: Fn(E::Span) -> O, E: Error<I>, const N: usize> 
 {
     fn recover<D: Debugger, P: Parser<I, O, Error = E>>(
         &self,
-        mut a_errors: Vec<Located<I, P::Error>>,
+        mut a_errors: FlatList<Located<I, P::Error>>,
         a_err: Located<I, P::Error>,
         _parser: P,
         _debugger: &mut D,
@@ -133,7 +133,7 @@ impl<I: Clone + PartialEq, O, F: Fn(E::Span) -> O, E: Error<I>, const N: usize> 
     #[allow(clippy::blocks_in_if_conditions)]
     fn recover<D: Debugger, P: Parser<I, O, Error = E>>(
         &self,
-        mut a_errors: Vec<Located<I, P::Error>>,
+        mut a_errors: FlatList<Located<I, P::Error>>,
         a_err: Located<I, P::Error>,
         _parser: P,
         _debugger: &mut D,

--- a/src/text.rs
+++ b/src/text.rs
@@ -141,7 +141,7 @@ pub fn whitespace<C: Character, E: Error<C>>() -> Padding<C, E> {
         let state = stream.save();
         if stream.next().2.map_or(true, |b| !b.is_whitespace()) {
             stream.revert(state);
-            break (Vec::new(), Ok(((), None)));
+            break (FlatList::new(), Ok(((), None)));
         }
     })
 }


### PR DESCRIPTION
You mentioned that you wanted to take some stabs at performance. While I am not familiar enough with the codebase to suggest any _structural_ changes (and sadly don't have the time to change that, as interesting as `chumsky` is), I had a look at the benchmarks and also `perf`ed them. The flamegraph has the usual problem of recursive and/or deeply layered parsing function that any parser expectedly consists mostly of its sub-parsers and it's hard to make out problematic areas. One part that showed up repeatedly was `Vec::push` and `Vec::append`. 

If I saw correctly, some parsers like `Seq` use a `Vec` as output as well, but on top-level I noticed all of the parsing errors are returned in a `Vec`, so many of the parsers copy them from outputs of their constituents into an aggregated result `Vec`. I replaced that with a wrapper around `LinkedList<Vec<T>>`  to obtain the `O(1)` characteristics of its `append`. It doesn't have everything that `Vec` has (in particular, no methods to remove elements), but everything that you use in `chumsky` plus `iter` and `into_iter`, so it's possible to get back to a `Vec` after parsing . On the Linux machine I tested this, making this change through all the parsers and also the recovery `Strategy`s made about a 10% difference. This depends heavily on the presence of errors, obviously.

Notables:
 - Breaking: the container type is exposed through `PResult`
 - Right now this PR increases the MSRV to current stable. That's only because I used `unwrap_unchecked` though, so if you want to support earlier versions that's an easy change
 - I added tests for the data structure, and also documented it briefly. I put the thing in its own new module, which is missing the quote in its module comment because I didn't feel qualified ^^