### PR TITLE
Fix Compilation Without AHash

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ use std::{collections::HashSet, hash::Hash};
 #[cfg(feature = "ahash")]
 type RandomState = ahash::RandomState;
 #[cfg(not(feature = "ahash"))]
-type RandomState = std::collections::hash_set::RandomState;
+type RandomState = std::collections::hash_map::RandomState;
 
 /// A trait that describes parser error types.
 ///


### PR DESCRIPTION
The stdlib `RandomState` is only available in the `hash_map` module