### PR TITLE
Fix JSON example to parse a number with exp like 1e5 correctry

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -23,7 +23,7 @@ fn parser() -> impl Parser<char, Json, Error = Simple<char>> {
 
         let exp = just('e')
             .or(just('E'))
-            .ignore_then(just('+').or(just('-')).or_not())
+            .chain(just('+').or(just('-')).or_not())
             .chain(text::digits(10));
 
         let number = just('-')


### PR DESCRIPTION
On `json` example on master parse a number with exp wrongly.

test.json
```json
{
    "value": 1e5
}
```
```
> cargo run --example json -- .\test.json
   Compiling chumsky v0.8.0 (C:\Users\hato2\Desktop\chumsky)
    Finished dev [unoptimized + debuginfo] target(s) in 4.12s
     Running `target\debug\examples\json.exe .\test.json`
Some(
    Object(
        {
            "value": Num(
                15.0,
            ),
        },
    ),
)
```

This PR fixes it.

```
> cargo run --example json -- .\test.json
   Compiling chumsky v0.8.0 (C:\Users\hato2\Desktop\chumsky)
    Finished dev [unoptimized + debuginfo] target(s) in 4.23s
     Running `target\debug\examples\json.exe .\test.json`
Some(
    Object(
        {
            "value": Num(
                100000.0,
            ),
        },
    ),
)
```