### PR TITLE
[zero-copy] Fix duplicate inline attributes and a doc warning

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -25,8 +25,8 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, B: Parser<I, O, Error = E>, E: Err
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -151,8 +151,8 @@ pub struct OrNot<A>(pub(crate) A);
 impl<I: Clone, O, A: Parser<I, O, Error = E>, E: Error<I>> Parser<I, Option<O>> for OrNot<A> {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -195,8 +195,8 @@ impl<I: Clone, O, U, A: Parser<I, O, Error = E>, B: Parser<I, U, Error = E>, E: 
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -265,8 +265,8 @@ impl<
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -335,8 +335,8 @@ impl<
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -429,8 +429,8 @@ impl<A> Repeated<A> {
 impl<I: Clone, O, A: Parser<I, O, Error = E>, E: Error<I>> Parser<I, Vec<O>> for Repeated<A> {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -657,8 +657,8 @@ impl<I: Clone, O, U, A: Parser<I, O, Error = E>, B: Parser<I, U, Error = E>, E: 
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -813,8 +813,8 @@ impl<A: Clone> Clone for Debug<A> {
 impl<I: Clone, O, A: Parser<I, O, Error = E>, E: Error<I>> Parser<I, O> for Debug<A> {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -857,8 +857,8 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, U, F: Fn(O) -> U, E: Error<I>> Par
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -896,8 +896,8 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, U, F: Fn(O, E::Span) -> U, E: Erro
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -945,8 +945,8 @@ impl<
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -1001,8 +1001,8 @@ impl<
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -1049,8 +1049,8 @@ where
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -1083,8 +1083,8 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, F: Fn(E) -> E, E: Error<I>> Parser
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -1120,8 +1120,8 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, F: Fn(E, E::Span) -> E, E: Error<I
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -1175,8 +1175,8 @@ impl<
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -1215,8 +1215,8 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, F: Fn(E) -> Result<O, E>, E: Error
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -1260,8 +1260,8 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, L: Into<E::Label> + Clone, E: Erro
 {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -1313,8 +1313,8 @@ impl<A: Clone, U: Clone, O> Clone for To<A, O, U> {
 impl<I: Clone, O, A: Parser<I, O, Error = E>, U: Clone, E: Error<I>> Parser<I, U> for To<A, O, U> {
     type Error = E;
 
-    #[inline]
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, E>,
@@ -1345,7 +1345,8 @@ where
 {
     type Error = E;
 
-    #[inline(always)] fn parse_inner<D: Debugger>(
+    #[inline(always)]
+    fn parse_inner<D: Debugger>(
         &self,
         debugger: &mut D,
         stream: &mut StreamOf<I, Self::Error>,

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -4,7 +4,7 @@
 //! "What's so unpleasant about being drunk?"
 //! "You ask a glass of water.”*
 //!
-//! The [`recursive`] function covers most cases, but sometimes it's necessary to manually control the declaration and
+//! The [`recursive()`] function covers most cases, but sometimes it's necessary to manually control the declaration and
 //! definition of parsers more corefully, particularly for mutually-recursive parsers. In such cases, the functions on
 //! [`Recursive`] allow for this.
 


### PR DESCRIPTION
I merged the duplicate `#[inline]` and `#[inline(always)]` attributes on some functions into just `#[inline(always)]` and ported a doc fix from master.