### PR TITLE
Support unicode character escapes in the JSON example

### DIFF
--- a/examples/sample.json
+++ b/examples/sample.json
@@ -15,6 +15,7 @@
     "origin": 981339097
   },
   "though": ~true,
+  "invalid": "\uDFFF",
   "activity": "value",
   "office": -342325541.1937506,
   "noise": fallse,


### PR DESCRIPTION
The error messages are kind of strange, but it's functional

Closes #86