### PR TITLE
[zero-copy] Re-add `no_std` support, add `separated_by_exactly`, and a few primitives

### DIFF
--- a/benches/json.rs
+++ b/benches/json.rs
@@ -122,10 +122,7 @@ mod chumsky_zero_copy {
 
             let array = value
                 .clone()
-                // .separated_by(just(b',').padded())
-                .then(just(b',').padded())
-                .map(|(x, _)| x)
-                .repeated()
+                .separated_by(just(b',').padded())
                 .collect::<Vec<_>>()
                 .then(value.clone().or_not())
                 .map(|(mut xs, x)| {
@@ -146,10 +143,7 @@ mod chumsky_zero_copy {
                 .then(value);
             let object = member
                 .clone()
-                //.separated_by(just(b',').padded())
-                .then(just(b',').padded())
-                .map(|(x, _)| x)
-                .repeated()
+                .separated_by(just(b',').padded())
                 .collect::<Vec<_>>()
                 .then(member.clone().or_not())
                 .map(|(mut xs, x)| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(any(doc, feature = "std", test)), no_std)]
 #![cfg_attr(
     feature = "nightly",
     feature(

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -377,6 +377,13 @@ impl<K: Eq + Hash, V> Container<(K, V)> for HashMap<K, V> {
     }
 }
 
+#[cfg(feature = "std")]
+impl<K: Eq + Hash, V> Container<(K, V)> for std::collections::HashMap<K, V> {
+    fn push(&mut self, (key, value): (K, V)) {
+        (*self).insert(key, value);
+    }
+}
+
 pub struct Repeated<A, I: ?Sized, C = (), E = (), S = ()> {
     pub(crate) parser: A,
     pub(crate) at_least: usize,
@@ -654,7 +661,7 @@ where
     type Output = [A::Output; N];
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
-        use std::mem::MaybeUninit;
+        use core::mem::MaybeUninit;
 
         let mut i = 0;
         let mut output = MaybeUninit::uninit_array();
@@ -715,7 +722,7 @@ where
     type Output = [A::Output; N];
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
-        use std::mem::MaybeUninit;
+        use core::mem::MaybeUninit;
 
         if self.allow_leading {
             let before_separator = inp.save();

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -36,6 +36,12 @@ pub mod prelude {
     };
 }
 
+use alloc::{
+    boxed::Box,
+    rc::{Rc, Weak},
+    string::String,
+    vec::Vec,
+};
 use core::{
     cmp::Eq,
     hash::Hash,
@@ -43,8 +49,7 @@ use core::{
     marker::PhantomData,
     ops::{Range, RangeFrom},
 };
-use std::collections::HashMap;
-use std::rc::{Rc, Weak};
+use hashbrown::HashMap;
 
 use self::{
     combinator::*,

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -25,7 +25,7 @@ pub mod text;
 pub mod prelude {
     pub use super::{
         error::Error as _,
-        primitive::{choice, end, filter, just, none_of},
+        primitive::{any, choice, empty, end, filter, just, none_of, one_of},
         // recovery::{nested_delimiters, skip_then_retry_until, skip_until},
         recursive::{recursive, Recursive},
         // select,
@@ -329,6 +329,18 @@ pub trait Parser<'a, I: Input + ?Sized, E: Error<I::Token> = (), S: 'a = ()> {
             allow_leading: false,
             allow_trailing: false,
             phantom: PhantomData,
+        }
+    }
+    
+    fn separated_by_exactly<B: Parser<'a, I, E, S>, const N: usize>(self, separator: B) -> SeparatedByExactly<Self, B, N>
+    where
+        Self: Sized,
+    {
+        SeparatedByExactly {
+            parser: self,
+            separator,
+            allow_leading: false,
+            allow_trailing: false,
         }
     }
 


### PR DESCRIPTION
Adds the `any`, `empty`, `one_of` primitives, the `separated_by_exactly` combinator, and `no_std` support back.