### PR TITLE
[zero-copy] Implement missing primitives

### DIFF
--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -25,7 +25,9 @@ pub mod text;
 pub mod prelude {
     pub use super::{
         error::Error as _,
-        primitive::{any, choice, empty, end, filter, just, none_of, one_of},
+        primitive::{
+            any, choice, empty, end, filter, filter_map, just, none_of, one_of, take_until, todo
+        },
         // recovery::{nested_delimiters, skip_then_retry_until, skip_until},
         recursive::{recursive, Recursive},
         // select,

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -423,10 +423,10 @@ where
 
         loop {
             let start = inp.save();
-            match self.until.go::<M>(inp) {
-                Ok(out) => break Ok(M::combine(output, out, |output, out| (output, out))),
-                Err(_) => ()
+            if let Ok(out) = self.until.go::<M>(inp) {
+                break Ok(M::combine(output, out, |output, out| (output, out)));
             }
+
             inp.rewind(start);
 
             match inp.next() {

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -395,7 +395,7 @@ impl<P: Clone, I: ?Sized, C, E, S> Clone for TakeUntil<P, I, C, E, S> {
     }
 }
 
-fn take_until<'a, P, I, E, S>(until: P) -> TakeUntil<P, I, (), E, S>
+pub fn take_until<'a, P, I, E, S>(until: P) -> TakeUntil<P, I, (), E, S>
 where
     I: Input + ?Sized,
     E: Error<I::Token>,


### PR DESCRIPTION
May need more testing, but these should be all the primitives in main but not zero-copy except the deprecated `seq`