### PR TITLE
fix tutorial code

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -404,7 +404,7 @@ recursive(|expr| {
         .padded();
 
     let atom = int
-        .or(expr.delimited_by(just('('), just(')')));
+        .or(expr.delimited_by(just('('), just(')'))).padded();
 
     let op = |c| just(c).padded();
 
@@ -429,7 +429,6 @@ recursive(|expr| {
 
     sum
 })
-    .padded()
     .then_ignore(end())
 ```
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -429,6 +429,7 @@ recursive(|expr| {
 
     sum
 })
+    .padded()
     .then_ignore(end())
 ```
 


### PR DESCRIPTION
I found that the code in the tutorial (Parsing parentheses) has an error.
That code doesn't work in the case: "3 * (4 + 2)".
By adding .padded(), that code works well.