### PR TITLE
Fix wording of documentation

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -277,7 +277,7 @@ pub fn digits<C: Character, E: Error<C>>(
         .collect()
 }
 
-/// A parser that accepts a positive integer.
+/// A parser that accepts a non-negative integer.
 ///
 /// An integer is defined as a non-empty sequence of ASCII digits, where the first digit is non-zero or the sequence
 /// has length one.

--- a/tutorial.md
+++ b/tutorial.md
@@ -197,7 +197,7 @@ let int = text::int(10)
 int.then_ignore(end())
 ```
 
-That's better. We've also swapped out our custom digit parser with a built-in parser that parses any positive
+That's better. We've also swapped out our custom digit parser with a built-in parser that parses any non-negative
 integer.
 
 ## Evaluating simple expressions


### PR DESCRIPTION
Thank you for a grate crate!

This PR replaces 2 occurrences of "positive integer" in the documentation with "non-negative integer", because `text::int` actually do parse `"0"` correctly as the doc says. 