### PR TITLE
Fixes #131 using Debug format to display errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -309,32 +309,31 @@ impl<I: fmt::Display + Hash + Eq, S: Span> fmt::Display for Simple<I, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // TODO: Take `self.reason` into account
 
-        let found = if let Some(found) = &self.found {
-            format!("{}", found)
+        if let Some(found) = &self.found {
+            write!(f, "found {:?}", found.to_string())?;
         } else {
-            format!("end of input")
+            write!(f, "found end of input")?;
         };
 
         match self.expected.len() {
             0 => {} //write!(f, " but end of input was expected")?,
             1 => write!(
                 f,
-                " but {} was expected",
+                " but expected {}",
                 match self.expected.iter().next().unwrap() {
-                    Some(x) => format!("'{}'", x),
-                    None => format!("end of input"),
+                    Some(x) => format!("{:?}", x.to_string()),
+                    None => "end of input".to_string(),
                 },
             )?,
             _ => {
                 write!(
                     f,
-                    "found {:?}, but one of {:?} was expected",
-                    found,
+                    " but expected one of {}",
                     self.expected
                         .iter()
                         .map(|expected| match expected {
-                            Some(x) => format!("{}", x),
-                            None => found.to_string(),
+                            Some(x) => format!("{:?}", x.to_string()),
+                            None => "end of input".to_string(),
                         })
                         .collect::<Vec<_>>()
                         .join(", ")

--- a/src/error.rs
+++ b/src/error.rs
@@ -312,7 +312,7 @@ impl<I: fmt::Display + Hash + Eq, S: Span> fmt::Display for Simple<I, S> {
         let found = if let Some(found) = &self.found {
             format!("{}", found)
         } else {
-            format!("found end of input")
+            format!("end of input")
         };
 
         match self.expected.len() {
@@ -328,7 +328,7 @@ impl<I: fmt::Display + Hash + Eq, S: Span> fmt::Display for Simple<I, S> {
             _ => {
                 write!(
                     f,
-                    r"found {:?}, but one of {:?} was expected",
+                    "found {:?}, but one of {:?} was expected",
                     found,
                     self.expected
                         .iter()

--- a/src/error.rs
+++ b/src/error.rs
@@ -309,11 +309,11 @@ impl<I: fmt::Display + Hash + Eq, S: Span> fmt::Display for Simple<I, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // TODO: Take `self.reason` into account
 
-        if let Some(found) = &self.found {
-            write!(f, "found '{}'", found)?;
+        let found = if let Some(found) = &self.found {
+            format!("{}", found)
         } else {
-            write!(f, "found end of input")?;
-        }
+            format!("found end of input")
+        };
 
         match self.expected.len() {
             0 => {} //write!(f, " but end of input was expected")?,
@@ -325,18 +325,21 @@ impl<I: fmt::Display + Hash + Eq, S: Span> fmt::Display for Simple<I, S> {
                     None => format!("end of input"),
                 },
             )?,
-            _ => write!(
-                f,
-                " but one of {} was expected",
-                self.expected
-                    .iter()
-                    .map(|expected| match expected {
-                        Some(x) => format!("'{}'", x),
-                        None => format!("end of input"),
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )?,
+            _ => {
+                write!(
+                    f,
+                    r"found {:?}, but one of {:?} was expected",
+                    found,
+                    self.expected
+                        .iter()
+                        .map(|expected| match expected {
+                            Some(x) => format!("{}", x),
+                            None => found.to_string(),
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
This change introduces a Debug-style representation for `Simple`. It
should close issue #131 as the output now closely matches the desired
output discussed in the issue.

There may be some edge-cases or areas for improvement. In that case,
please let me know and I'll be happy to revise the PR.