### PR TITLE
[zero-copy] make map_with_state consitent with other maps / try_map_with_state

### DIFF
--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -156,8 +156,8 @@ impl<'a, I, E, S, A, F, O> Parser<'a, I, E, S> for MapWithState<A, F>
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
         let before = inp.save();
-        self.parser.go::<M>(inp).map(|out| {
-            M::map(out, |out| {
+        self.parser.go::<Emit>(inp).map(|out| {
+            M::bind(|| {
                 let span = inp.span_since(before);
                 let state = inp.state();
                 (self.mapper)(out, span, state)

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -150,17 +150,18 @@ impl<'a, I, E, S, A, F, O> Parser<'a, I, E, S> for MapWithState<A, F>
         E: Error<I>,
         S: 'a,
         A: Parser<'a, I, E, S>,
-        F: Fn(A::Output, &mut S) -> Result<O, E>,
+        F: Fn(A::Output, I::Span, &mut S) -> O,
 {
     type Output = O;
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
-        self.parser.go::<Emit>(inp).and_then(|out| {
-            let state = inp.state();
-            match (self.mapper)(out, state) {
-                Ok(out) => Ok(M::bind(|| out)),
-                Err(e) => Err(Located::at(inp.last_pos(), e)),
-            }
+        let before = inp.save();
+        self.parser.go::<M>(inp).map(|out| {
+            M::map(out, |out| {
+                let span = inp.span_since(before);
+                let state = inp.state();
+                (self.mapper)(out, span, state)
+            })
         })
     }
 

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -255,7 +255,7 @@ pub trait Parser<'a, I: Input + ?Sized, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn map_with_state<O, F: Fn(Self::Output, S) -> O>(self, f: F) -> MapWithState<Self, F>
+    fn map_with_state<O, F: Fn(Self::Output, I::Span, &mut S) -> O>(self, f: F) -> MapWithState<Self, F>
     where
         Self: Sized,
     {


### PR DESCRIPTION
Make map_with_state non-fallible, and elide it in check mode like `map` or `map_with_span`

This may be more iffy, as the user may mutate the state. One option would be to make `map_with_state` pass in a `&S` instead of `&mut S`, to indicate that it is supposed to read-only the state, and force `try_map_with_state` if you rely on the output.