### PR TITLE
adding default display implementation for SimpleReason

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -166,14 +166,12 @@ pub enum SimpleReason<I, S> {
     Custom(String),
 }
 
-impl<I, S> SimpleReason<I, S> {
-    const DEFAULT_DISPLAY_UNEXPECTED: &'static str = "unexpected value";
-}
-
 impl<I: fmt::Display, S: fmt::Display> fmt::Display for SimpleReason<I, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const DEFAULT_DISPLAY_UNEXPECTED: &'static str = "unexpected input";
+
         match self {
-            Self::Unexpected => write!(f, "{}", Self::DEFAULT_DISPLAY_UNEXPECTED),
+            Self::Unexpected => write!(f, "{}", DEFAULT_DISPLAY_UNEXPECTED),
             Self::Unclosed {span, delimiter} => write!(f, "unclosed delimiter ({}) in {}", span, delimiter),
             Self::Custom(string) => write!(f, "error {}", string),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -166,6 +166,20 @@ pub enum SimpleReason<I, S> {
     Custom(String),
 }
 
+impl<I, S> SimpleReason<I, S> {
+    const DEFAULT_DISPLAY_UNEXPECTED: &'static str = "unexpected value";
+}
+
+impl<I: fmt::Display, S: fmt::Display> fmt::Display for SimpleReason<I, S> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Unexpected => write!(f, "{}", Self::DEFAULT_DISPLAY_UNEXPECTED),
+            Self::Unclosed {span, delimiter} => write!(f, "unclosed delimiter ({}) in {}", span, delimiter),
+            Self::Custom(string) => write!(f, "error {}", string),
+        }
+    }
+}
+
 /// A simple default error type that tracks error spans, expected inputs, and the actual input found at an error site.
 ///
 /// Please note that it uses a [`HashSet`] to remember expected symbols. If you find this to be too slow, you can


### PR DESCRIPTION
A possible default `Display` implementation for `SimpleReason`(?)

Comes from https://github.com/zesterer/chumsky/issues/157