### PR TITLE
Resolve issue #174 - #[must_use]

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -17,6 +17,7 @@ pub type IgnoreThen<A, B, O, U> = Map<Then<A, B>, fn((O, U)) -> U, (O, U)>;
 pub type ThenIgnore<A, B, O, U> = Map<Then<A, B>, fn((O, U)) -> O, (O, U)>;
 
 /// See [`Parser::or`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct Or<A, B>(pub(crate) A, pub(crate) B);
 
@@ -168,6 +169,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, B: Parser<I, O, Error = E>, E: Err
 }
 
 /// See [`Parser::or_not`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct OrNot<A>(pub(crate) A);
 
@@ -210,6 +212,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, E: Error<I>> Parser<I, Option<O>> 
 }
 
 /// See [`Parser::then`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct Then<A, B>(pub(crate) A, pub(crate) B);
 
@@ -262,6 +265,7 @@ impl<I: Clone, O, U, A: Parser<I, O, Error = E>, B: Parser<I, U, Error = E>, E: 
 }
 
 /// See [`Parser::then_with`]
+#[must_use]
 pub struct ThenWith<I, O1, O2, A, B, F>(
     pub(crate) A,
     pub(crate) F,
@@ -337,6 +341,7 @@ impl<
 }
 
 /// See [`Parser::delimited_by`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct DelimitedBy<A, L, R, U, V> {
     pub(crate) item: A,
@@ -390,6 +395,7 @@ impl<
 }
 
 /// See [`Parser::repeated`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct Repeated<A>(pub(crate) A, pub(crate) usize, pub(crate) Option<usize>);
 
@@ -531,6 +537,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, E: Error<I>> Parser<I, Vec<O>> for
 }
 
 /// See [`Parser::separated_by`].
+#[must_use]
 pub struct SeparatedBy<A, B, U> {
     pub(crate) item: A,
     pub(crate) delimiter: B,
@@ -821,6 +828,7 @@ impl<I: Clone, O, U, A: Parser<I, O, Error = E>, B: Parser<I, U, Error = E>, E: 
 }
 
 /// See [`Parser::debug`].
+#[must_use]
 pub struct Debug<A>(
     pub(crate) A,
     pub(crate) Rc<dyn fmt::Display>,
@@ -866,6 +874,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, E: Error<I>> Parser<I, O> for Debu
 }
 
 /// See [`Parser::map`].
+#[must_use]
 pub struct Map<A, F, O>(pub(crate) A, pub(crate) F, pub(crate) PhantomData<O>);
 
 impl<A: Copy, F: Copy, O> Copy for Map<A, F, O> {}
@@ -905,6 +914,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, U, F: Fn(O) -> U, E: Error<I>> Par
 }
 
 /// See [`Parser::map_with_span`].
+#[must_use]
 pub struct MapWithSpan<A, F, O>(pub(crate) A, pub(crate) F, pub(crate) PhantomData<O>);
 
 impl<A: Copy, F: Copy, O> Copy for MapWithSpan<A, F, O> {}
@@ -948,6 +958,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, U, F: Fn(O, E::Span) -> U, E: Erro
 }
 
 /// See [`Parser::validate`].
+#[must_use]
 pub struct Validate<A, U, F>(pub(crate) A, pub(crate) F, pub(crate) PhantomData<U>);
 
 impl<A: Copy, U, F: Copy> Copy for Validate<A, U, F> {}
@@ -1004,6 +1015,7 @@ impl<
 }
 
 /// See [`Parser::foldl`].
+#[must_use]
 pub struct Foldl<A, F, O, U>(pub(crate) A, pub(crate) F, pub(crate) PhantomData<(O, U)>);
 
 impl<A: Copy, F: Copy, O, U> Copy for Foldl<A, F, O, U> {}
@@ -1050,6 +1062,7 @@ impl<
 }
 
 /// See [`Parser::foldr`].
+#[must_use]
 pub struct Foldr<A, F, O, U>(pub(crate) A, pub(crate) F, pub(crate) PhantomData<(O, U)>);
 
 impl<A: Copy, F: Copy, O, U> Copy for Foldr<A, F, O, U> {}
@@ -1098,6 +1111,7 @@ where
 }
 
 /// See [`Parser::map_err`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct MapErr<A, F>(pub(crate) A, pub(crate) F);
 
@@ -1135,6 +1149,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, F: Fn(E) -> E, E: Error<I>> Parser
 }
 
 /// See [`Parser::map_err_with_span`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct MapErrWithSpan<A, F>(pub(crate) A, pub(crate) F);
 
@@ -1178,6 +1193,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, F: Fn(E, E::Span) -> E, E: Error<I
 }
 
 /// See [`Parser::try_map`].
+#[must_use]
 pub struct TryMap<A, F, O>(pub(crate) A, pub(crate) F, pub(crate) PhantomData<O>);
 
 impl<A: Copy, F: Copy, O> Copy for TryMap<A, F, O> {}
@@ -1230,6 +1246,7 @@ impl<
 }
 
 /// See [`Parser::or_else`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct OrElse<A, F>(pub(crate) A, pub(crate) F);
 
@@ -1275,6 +1292,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, F: Fn(E) -> Result<O, E>, E: Error
 }
 
 /// See [`Parser::labelled`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct Label<A, L>(pub(crate) A, pub(crate) L);
 
@@ -1324,6 +1342,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, L: Into<E::Label> + Clone, E: Erro
 }
 
 /// See [`Parser::to`].
+#[must_use]
 pub struct To<A, O, U>(pub(crate) A, pub(crate) U, pub(crate) PhantomData<O>);
 
 impl<A: Copy, U: Copy, O> Copy for To<A, O, U> {}
@@ -1359,6 +1378,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, U: Clone, E: Error<I>> Parser<I, U
 }
 
 /// See [`Parser::rewind`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct Rewind<A>(pub(crate) A);
 
@@ -1409,6 +1429,7 @@ where
 }
 
 /// See [`Parser::unwrapped`]
+#[must_use]
 pub struct Unwrapped<A, U, E>(pub(crate) &'static Location<'static>, pub(crate) A, pub(crate) PhantomData<(U, E)>);
 
 impl<A: Clone, U, E> Clone for Unwrapped<A, U, E> {

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1430,7 +1430,11 @@ where
 
 /// See [`Parser::unwrapped`]
 #[must_use]
-pub struct Unwrapped<A, U, E>(pub(crate) &'static Location<'static>, pub(crate) A, pub(crate) PhantomData<(U, E)>);
+pub struct Unwrapped<A, U, E>(
+    pub(crate) &'static Location<'static>,
+    pub(crate) A,
+    pub(crate) PhantomData<(U, E)>,
+);
 
 impl<A: Clone, U, E> Clone for Unwrapped<A, U, E> {
     fn clone(&self) -> Self {
@@ -1440,7 +1444,7 @@ impl<A: Clone, U, E> Clone for Unwrapped<A, U, E> {
 impl<A: Copy, U, E> Copy for Unwrapped<A, U, E> {}
 
 impl<I: Clone, O, A: Parser<I, Result<O, U>, Error = E>, U: fmt::Debug, E: Error<I>> Parser<I, O>
-for Unwrapped<A, U, E>
+    for Unwrapped<A, U, E>
 {
     type Error = E;
 
@@ -1455,7 +1459,17 @@ for Unwrapped<A, U, E>
 
         (
             errors,
-            res.map(|(out, alt)| (out.unwrap_or_else(|err| panic!("Parser defined at {} failed to unwrap. Error: {:?}", self.0, err)), alt))
+            res.map(|(out, alt)| {
+                (
+                    out.unwrap_or_else(|err| {
+                        panic!(
+                            "Parser defined at {} failed to unwrap. Error: {:?}",
+                            self.0, err
+                        )
+                    }),
+                    alt,
+                )
+            }),
         )
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -172,7 +172,9 @@ impl<I: fmt::Display, S: fmt::Display> fmt::Display for SimpleReason<I, S> {
 
         match self {
             Self::Unexpected => write!(f, "{}", DEFAULT_DISPLAY_UNEXPECTED),
-            Self::Unclosed {span, delimiter} => write!(f, "unclosed delimiter ({}) in {}", span, delimiter),
+            Self::Unclosed { span, delimiter } => {
+                write!(f, "unclosed delimiter ({}) in {}", span, delimiter)
+            }
             Self::Custom(string) => write!(f, "error {}", string),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -168,7 +168,7 @@ pub enum SimpleReason<I, S> {
 
 impl<I: fmt::Display, S: fmt::Display> fmt::Display for SimpleReason<I, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const DEFAULT_DISPLAY_UNEXPECTED: &'static str = "unexpected input";
+        const DEFAULT_DISPLAY_UNEXPECTED: &str = "unexpected input";
 
         match self {
             Self::Unexpected => write!(f, "{}", DEFAULT_DISPLAY_UNEXPECTED),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use crate::{
     recovery::*,
 };
 
-use alloc::{boxed::Box, rc::Rc, string::String, sync::Arc, vec::Vec, vec};
+use alloc::{boxed::Box, rc::Rc, string::String, sync::Arc, vec, vec::Vec};
 use core::{
     cmp::Ordering,
     // TODO: Enable when stable
@@ -38,8 +38,8 @@ use core::{
     fmt,
     marker::PhantomData,
     ops::Range,
-    str::FromStr,
     panic::Location,
+    str::FromStr,
 };
 
 #[cfg(doc)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1301,6 +1301,7 @@ impl<I: Clone, O, T: Parser<I, O> + ?Sized> Parser<I, O> for Arc<T> {
 /// efficient cloning. This is likely to change in the future. Unlike [`Box`], [`Rc`] has no size guarantees: although
 /// it is *currently* the same size as a raw pointer.
 // TODO: Don't use an Rc
+#[must_use]
 #[repr(transparent)]
 pub struct BoxedParser<'a, I, O, E: Error<I>>(Rc<dyn Parser<I, O, Error = E> + 'a>);
 

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -17,6 +17,7 @@ use super::*;
 use core::panic::Location;
 
 /// See [`custom`].
+#[must_use]
 pub struct Custom<F, E>(F, PhantomData<E>);
 
 impl<F: Copy, E> Copy for Custom<F, E> {}
@@ -60,6 +61,7 @@ pub fn custom<F, E>(f: F) -> Custom<F, E> {
 }
 
 /// See [`end`].
+#[must_use]
 pub struct End<E>(PhantomData<E>);
 
 impl<E> Clone for End<E> {
@@ -277,6 +279,7 @@ impl<T: Clone> OrderedContainer<T> for alloc::collections::LinkedList<T> {}
 impl<T: Clone> OrderedContainer<T> for alloc::collections::VecDeque<T> {}
 
 /// See [`just`].
+#[must_use]
 pub struct Just<I, C: OrderedContainer<I>, E>(C, PhantomData<(I, E)>);
 
 impl<I, C: Copy + OrderedContainer<I>, E> Copy for Just<I, C, E> {}
@@ -344,6 +347,7 @@ pub fn just<I, C: OrderedContainer<I>, E: Error<I>>(inputs: C) -> Just<I, C, E> 
 }
 
 /// See [`seq`].
+#[must_use]
 pub struct Seq<I, E>(Vec<I>, PhantomData<E>);
 
 impl<I: Clone, E> Clone for Seq<I, E> {
@@ -417,6 +421,7 @@ pub fn seq<I: Clone + PartialEq, Iter: IntoIterator<Item = I>, E>(xs: Iter) -> S
 }
 
 /// See [`one_of`].
+#[must_use]
 pub struct OneOf<I, C, E>(C, PhantomData<(I, E)>);
 
 impl<I, C: Clone, E> Clone for OneOf<I, C, E> {
@@ -478,6 +483,7 @@ pub fn one_of<I, C: Container<I>, E: Error<I>>(inputs: C) -> OneOf<I, C, E> {
 }
 
 /// See [`empty`].
+#[must_use]
 pub struct Empty<E>(PhantomData<E>);
 
 impl<E> Clone for Empty<E> {
@@ -515,6 +521,7 @@ pub fn empty<E>() -> Empty<E> {
 }
 
 /// See [`none_of`].
+#[must_use]
 pub struct NoneOf<I, C, E>(C, PhantomData<(I, E)>);
 
 impl<I, C: Clone, E> Clone for NoneOf<I, C, E> {
@@ -578,6 +585,7 @@ pub fn none_of<I, C: Container<I>, E: Error<I>>(inputs: C) -> NoneOf<I, C, E> {
 }
 
 /// See [`take_until`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct TakeUntil<A>(A);
 
@@ -673,6 +681,7 @@ pub fn take_until<A>(until: A) -> TakeUntil<A> {
 }
 
 /// See [`filter`].
+#[must_use]
 pub struct Filter<F, E>(F, PhantomData<E>);
 
 impl<F: Copy, E> Copy for Filter<F, E> {}
@@ -733,6 +742,7 @@ pub fn filter<I, F: Fn(&I) -> bool, E>(f: F) -> Filter<F, E> {
 }
 
 /// See [`filter_map`].
+#[must_use]
 pub struct FilterMap<F, E>(F, PhantomData<E>);
 
 impl<F: Copy, E> Copy for FilterMap<F, E> {}
@@ -822,6 +832,7 @@ pub fn any<I, E>() -> Any<I, E> {
 }
 
 /// See [`fn@todo`].
+#[must_use]
 pub struct Todo<I, O, E>(&'static Location<'static>, PhantomData<(I, O, E)>);
 
 /// A parser that can be used wherever you need to implement a parser later.
@@ -894,6 +905,7 @@ impl<I: Clone, O, E: Error<I>> Parser<I, O> for Todo<I, O, E> {
 }
 
 /// See [`choice`].
+#[must_use]
 pub struct Choice<T, E>(pub(crate) T, pub(crate) PhantomData<E>);
 
 impl<T: Copy, E> Copy for Choice<T, E> {}

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -289,7 +289,9 @@ impl<I, C: Clone + OrderedContainer<I>, E> Clone for Just<I, C, E> {
     }
 }
 
-impl<I: Clone + PartialEq, C: OrderedContainer<I> + Clone, E: Error<I>> Parser<I, C> for Just<I, C, E> {
+impl<I: Clone + PartialEq, C: OrderedContainer<I> + Clone, E: Error<I>> Parser<I, C>
+    for Just<I, C, E>
+{
     type Error = E;
 
     fn parse_inner<D: Debugger>(
@@ -915,7 +917,9 @@ impl<T: Clone, E> Clone for Choice<T, E> {
     }
 }
 
-impl<I: Clone, O, E: Error<I>, A: Parser<I, O, Error = E>, const N: usize> Parser<I, O> for Choice<[A; N], E> {
+impl<I: Clone, O, E: Error<I>, A: Parser<I, O, Error = E>, const N: usize> Parser<I, O>
+    for Choice<[A; N], E>
+{
     type Error = E;
 
     fn parse_inner<D: Debugger>(
@@ -934,7 +938,7 @@ impl<I: Clone, O, E: Error<I>, A: Parser<I, O, Error = E>, const N: usize> Parse
                 (errors, Ok(out)) => return (errors, Ok(out)),
                 (_, Err(a_alt)) => {
                     alt = merge_alts(alt.take(), Some(a_alt));
-                },
+                }
             };
         }
 
@@ -979,7 +983,7 @@ impl<I: Clone, O, E: Error<I>, A: Parser<I, O, Error = E>> Parser<I, O> for Choi
                 (errors, Ok(out)) => return (errors, Ok(out)),
                 (_, Err(a_alt)) => {
                     alt = merge_alts(alt.take(), Some(a_alt));
-                },
+                }
             };
         }
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -18,6 +18,7 @@ pub trait Strategy<I: Clone, O, E: Error<I>> {
 }
 
 /// See [`skip_then_retry_until`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct SkipThenRetryUntil<I, const N: usize>(
     pub(crate) [I; N],
@@ -91,6 +92,7 @@ pub fn skip_then_retry_until<I, const N: usize>(until: [I; N]) -> SkipThenRetryU
 }
 
 /// See [`skip_until`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct SkipUntil<I, F, const N: usize>(
     pub(crate) [I; N],
@@ -172,6 +174,7 @@ pub fn skip_until<I, F, const N: usize>(until: [I; N], fallback: F) -> SkipUntil
 }
 
 /// See [`nested_delimiters`].
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct NestedDelimiters<I, F, const N: usize>(
     pub(crate) I,
@@ -311,6 +314,7 @@ pub fn nested_delimiters<I: PartialEq, F, const N: usize>(
 }
 
 /// A parser that includes a fallback recovery strategy should parsing result in an error.
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct Recovery<A, S>(pub(crate) A, pub(crate) S);
 

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -46,6 +46,7 @@ type OnceParser<'a, I, O, E> = OnceCell<Box<dyn Parser<I, O, Error = E> + 'a>>;
 /// [definition](Recursive::define).
 ///
 /// Prefer to use [`recursive()`], which exists as a convenient wrapper around both operations, if possible.
+#[must_use]
 pub struct Recursive<'a, I, O, E: Error<I>>(RecursiveInner<OnceParser<'a, I, O, E>>);
 
 impl<'a, I: Clone, O, E: Error<I>> Recursive<'a, I, O, E> {

--- a/src/text.rs
+++ b/src/text.rs
@@ -25,6 +25,7 @@ pub type Padding<I, E> = Custom<fn(&mut StreamOf<I, E>) -> PResult<I, (), E>, E>
 // >;
 
 /// A parser that accepts (and ignores) any number of whitespace characters before or after another pattern.
+#[must_use]
 #[derive(Copy, Clone)]
 pub struct Padded<A>(A);
 
@@ -228,6 +229,7 @@ pub fn whitespace<'a, C: Character + 'a, E: Error<C> + 'a>(
 /// assert_eq!(newline.parse("\u{2028}"), Ok(()));
 /// assert_eq!(newline.parse("\u{2029}"), Ok(()));
 /// ```
+#[must_use]
 pub fn newline<'a, C: Character + 'a, E: Error<C> + 'a>(
 ) -> impl Parser<C, (), Error = E> + Copy + Clone + 'a {
     just(C::from_ascii(b'\r'))
@@ -268,6 +270,7 @@ pub fn newline<'a, C: Character + 'a, E: Error<C> + 'a>(
 /// assert_eq!(digits.parse("0000"), Ok("0000".to_string()));
 /// assert!(digits.parse("").is_err());
 /// ```
+#[must_use]
 pub fn digits<C: Character, E: Error<C>>(
     radix: u32,
 ) -> impl Parser<C, C::Collection, Error = E> + Copy + Clone {
@@ -308,6 +311,7 @@ pub fn digits<C: Character, E: Error<C>>(
 /// assert_eq!(hex.parse("b4"), Ok("b4".to_string()));
 /// assert!(hex.parse("0B").is_err());
 /// ```
+#[must_use]
 pub fn int<C: Character, E: Error<C>>(
     radix: u32,
 ) -> impl Parser<C, C::Collection, Error = E> + Copy + Clone {
@@ -325,6 +329,7 @@ pub fn int<C: Character, E: Error<C>>(
 ///
 /// An identifier is defined as an ASCII alphabetic character or an underscore followed by any number of alphanumeric
 /// characters or underscores. The regex pattern for it is `[a-zA-Z_][a-zA-Z0-9_]*`.
+#[must_use]
 pub fn ident<C: Character, E: Error<C>>() -> impl Parser<C, C::Collection, Error = E> + Copy + Clone
 {
     filter(|c: &C| c.to_char().is_ascii_alphabetic() || c.to_char() == '_')
@@ -352,6 +357,7 @@ pub fn ident<C: Character, E: Error<C>>() -> impl Parser<C, C::Collection, Error
 /// // 'def' was found, but only as part of a larger identifier, so this fails to parse
 /// assert!(def.parse("define").is_err());
 /// ```
+#[must_use]
 pub fn keyword<'a, C: Character + 'a, S: AsRef<C::Str> + 'a + Clone, E: Error<C> + 'a>(
     keyword: S,
 ) -> impl Parser<C, (), Error = E> + Clone + 'a {
@@ -368,6 +374,7 @@ pub fn keyword<'a, C: Character + 'a, S: AsRef<C::Str> + 'a + Clone, E: Error<C>
 /// A parser that consumes text and generates tokens using semantic whitespace rules and the given token parser.
 ///
 /// Also required is a function that collects a [`Vec`] of tokens into a whitespace-indicated token tree.
+#[must_use]
 pub fn semantic_indentation<'a, C, Tok, T, F, E: Error<C> + 'a>(
     token: T,
     make_group: F,

--- a/src/text.rs
+++ b/src/text.rs
@@ -425,7 +425,7 @@ where
             if let Some(tail) = collapse(nesting.split_off(i), &make_group) {
                 nesting.last_mut().unwrap().1.push(tail);
             }
-            if indent.len() > 0 {
+            if !indent.is_empty() {
                 nesting.push((indent.to_vec(), line));
             } else {
                 nesting.last_mut().unwrap().1.append(&mut line);

--- a/src/text.rs
+++ b/src/text.rs
@@ -194,7 +194,7 @@ impl<I: Character, O, P: Parser<I, O>> TextParser<I, O> for P {}
 /// assert_eq!(whitespace.parse(""), Ok(vec![]));
 /// ```
 pub fn whitespace<'a, C: Character + 'a, E: Error<C> + 'a>(
-) -> Repeated<impl Parser<C, (), Error=E>+Copy+Clone + 'a>{
+) -> Repeated<impl Parser<C, (), Error = E> + Copy + Clone + 'a> {
     filter(|c: &C| c.is_whitespace()).ignored().repeated()
 }
 


### PR DESCRIPTION
This pull request just adds the desired #[must_use] (issue #174) attribute to the various Parsers, as well as functions that produce Parsers, such as `text::ident` and the like. Hopefully I got all of them :D

Additionally, I ran `cargo fmt` and fixed up two clippy issues. 