### PR TITLE
ZeroCopy: All of `zero_copy::text`

### DIFF
--- a/benches/json.rs
+++ b/benches/json.rs
@@ -73,7 +73,8 @@ mod chumsky_zero_copy {
         recursive(|value| {
             let digits = any().filter(|b: &u8| b.is_ascii_digit()).repeated();
 
-            let int = any().filter(|b: &u8| b.is_ascii_digit() && *b != b'0')
+            let int = any()
+                .filter(|b: &u8| b.is_ascii_digit() && *b != b'0')
                 .then(any().filter(|b: &u8| b.is_ascii_digit()).repeated())
                 .ignored()
                 .or(just(b'0').ignored());
@@ -107,7 +108,8 @@ mod chumsky_zero_copy {
                 .ignored()
                 .boxed();
 
-            let string = any().filter(|c| *c != b'\\' && *c != b'"')
+            let string = any()
+                .filter(|c| *c != b'\\' && *c != b'"')
                 .ignored()
                 .or(escape)
                 .repeated()

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -60,12 +60,12 @@ impl<A: Clone, F: Clone> Clone for Filter<A, F> {
 }
 
 impl<'a, A, I, E, S, F> Parser<'a, I, E, S> for Filter<A, F>
-    where
-        I: Input + ?Sized,
-        E: Error<I>,
-        S: 'a,
-        A: Parser<'a, I, E, S>,
-        F: Fn(&A::Output) -> bool,
+where
+    I: Input + ?Sized,
+    E: Error<I>,
+    S: 'a,
+    A: Parser<'a, I, E, S>,
+    F: Fn(&A::Output) -> bool,
 {
     type Output = A::Output;
 
@@ -76,7 +76,10 @@ impl<'a, A, I, E, S, F> Parser<'a, I, E, S> for Filter<A, F>
                 Ok(M::bind(|| out))
             } else {
                 let span = inp.span_since(before);
-                Err(Located::at(inp.last_pos(), E::expected_found(None, None, span)))
+                Err(Located::at(
+                    inp.last_pos(),
+                    E::expected_found(None, None, span),
+                ))
             }
         })
     }
@@ -145,12 +148,12 @@ pub struct MapWithState<A, F> {
 }
 
 impl<'a, I, E, S, A, F, O> Parser<'a, I, E, S> for MapWithState<A, F>
-    where
-        I: Input + ?Sized,
-        E: Error<I>,
-        S: 'a,
-        A: Parser<'a, I, E, S>,
-        F: Fn(A::Output, I::Span, &mut S) -> O,
+where
+    I: Input + ?Sized,
+    E: Error<I>,
+    S: 'a,
+    A: Parser<'a, I, E, S>,
+    F: Fn(A::Output, I::Span, &mut S) -> O,
 {
     type Output = O;
 
@@ -205,12 +208,12 @@ pub struct TryMapWithState<A, F> {
 }
 
 impl<'a, I, E, S, A, F, O> Parser<'a, I, E, S> for TryMapWithState<A, F>
-    where
-        I: Input + ?Sized,
-        E: Error<I>,
-        S: 'a,
-        A: Parser<'a, I, E, S>,
-        F: Fn(A::Output, I::Span, &mut S) -> Result<O, E>,
+where
+    I: Input + ?Sized,
+    E: Error<I>,
+    S: 'a,
+    A: Parser<'a, I, E, S>,
+    F: Fn(A::Output, I::Span, &mut S) -> Result<O, E>,
 {
     type Output = O;
 
@@ -1224,11 +1227,10 @@ where
     where
         Self: Sized,
     {
-        self.parser.go::<M>(inp)
-            .map_err(|mut e| {
-                e.err = (self.mapper)(e.err);
-                e
-            })
+        self.parser.go::<M>(inp).map_err(|mut e| {
+            e.err = (self.mapper)(e.err);
+            e
+        })
     }
 
     go_extra!();
@@ -1255,12 +1257,11 @@ where
         Self: Sized,
     {
         let start = inp.save();
-        self.parser.go::<M>(inp)
-            .map_err(|mut e| {
-                let span = inp.span_since(start);
-                e.err = (self.mapper)(e.err, span);
-                e
-            })
+        self.parser.go::<M>(inp).map_err(|mut e| {
+            let span = inp.span_since(start);
+            e.err = (self.mapper)(e.err, span);
+            e
+        })
     }
 
     go_extra!();
@@ -1287,12 +1288,11 @@ where
         Self: Sized,
     {
         let start = inp.save();
-        self.parser.go::<M>(inp)
-            .map_err(|mut e| {
-                let span = inp.span_since(start);
-                e.err = (self.mapper)(e.err, span, inp.state());
-                e
-            })
+        self.parser.go::<M>(inp).map_err(|mut e| {
+            let span = inp.span_since(start);
+            e.err = (self.mapper)(e.err, span, inp.state());
+            e
+        })
     }
 
     go_extra!();
@@ -1354,15 +1354,13 @@ where
     {
         match self.parser.go::<M>(inp) {
             Ok(o) => Ok(o),
-            Err(err) => {
-                match (self.or_else)(err.err) {
-                    Err(e) => Err(Located {
-                        pos: err.pos,
-                        err: e,
-                    }),
-                    Ok(out) => Ok(M::bind(|| out)),
-                }
-            }
+            Err(err) => match (self.or_else)(err.err) {
+                Err(e) => Err(Located {
+                    pos: err.pos,
+                    err: e,
+                }),
+                Ok(out) => Ok(M::bind(|| out)),
+            },
         }
     }
 

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -62,7 +62,7 @@ use self::{
     error::Error,
     input::{Input, InputRef, SliceInput, StrInput},
     internal::*,
-    sliced::RepeatedSlice,
+    sliced::{RepeatedSlice, ThenSlice},
     span::Span,
     text::*,
 };
@@ -319,6 +319,18 @@ pub trait Parser<'a, I: Input + ?Sized, E: Error<I> = (), S: 'a = ()> {
         Self: Sized,
     {
         Then {
+            parser_a: self,
+            parser_b: other,
+            phantom: PhantomData,
+        }
+    }
+
+    fn then_slice<B>(self, other: B) -> ThenSlice<Self, B, E, S>
+    where
+        Self: Sized,
+        B: Parser<'a, I, E, S>,
+    {
+        ThenSlice {
             parser_a: self,
             parser_b: other,
             phantom: PhantomData,

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -20,6 +20,7 @@ pub mod primitive;
 pub mod recursive;
 #[cfg(feature = "regex")]
 pub mod regex;
+pub mod sliced;
 pub mod span;
 pub mod text;
 
@@ -61,6 +62,7 @@ use self::{
     error::Error,
     input::{Input, InputRef, SliceInput, StrInput},
     internal::*,
+    sliced::RepeatedSlice,
     span::Span,
     text::*,
 };
@@ -420,6 +422,18 @@ pub trait Parser<'a, I: Input + ?Sized, E: Error<I> = (), S: 'a = ()> {
         RepeatedExactly {
             parser: self,
             phantom: PhantomData,
+        }
+    }
+
+    fn repeated_slice(self) -> RepeatedSlice<Self, I, E, S>
+    where
+        Self: Sized,
+    {
+        RepeatedSlice {
+            parser: self,
+            at_least: 0,
+            at_most: None,
+            phantom: PhantomData::<(E, S, I)>,
         }
     }
 

--- a/src/zero_copy/regex.rs
+++ b/src/zero_copy/regex.rs
@@ -32,7 +32,12 @@ where
                 M::bind(|| inp.slice(before..after))
             })
             // TODO: Make this error actually correct
-            .ok_or_else(|| Located::at(inp.last_pos(), E::expected_found(None, None, inp.span_since(before))))
+            .ok_or_else(|| {
+                Located::at(
+                    inp.last_pos(),
+                    E::expected_found(None, None, inp.span_since(before)),
+                )
+            })
     }
 
     go_extra!();

--- a/src/zero_copy/sliced.rs
+++ b/src/zero_copy/sliced.rs
@@ -63,11 +63,11 @@ impl<'a, A, I, E, S> Parser<'a, I, E, S> for RepeatedSlice<A, I, E, S>
 where
     A: Parser<'a, I, E, S>,
     I: SliceInput + ?Sized,
-    <I as SliceInput>::Slice: 'a,
+    I::Slice: 'a,
     E: Error<I>,
     S: 'a,
 {
-    type Output = &'a <I as SliceInput>::Slice;
+    type Output = &'a I::Slice;
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
         let mut count = 0;
@@ -122,11 +122,11 @@ where
     A: Parser<'a, I, E, S>,
     B: Parser<'a, I, E, S>,
     I: SliceInput + ?Sized,
-    <I as SliceInput>::Slice: 'a,
+    I::Slice: 'a,
     E: Error<I>,
     S: 'a,
 {
-    type Output = &'a <I as SliceInput>::Slice;
+    type Output = &'a I::Slice;
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
         let now = inp.save();

--- a/src/zero_copy/sliced.rs
+++ b/src/zero_copy/sliced.rs
@@ -59,13 +59,13 @@ impl<'a, A: Parser<'a, I, E, S>, I: Input + ?Sized, E: Error<I>, S: 'a> Repeated
     }
 }
 
-impl<'a, I, E, S, A> Parser<'a, I, E, S> for RepeatedSlice<A, I, E, S>
+impl<'a, A, I, E, S> Parser<'a, I, E, S> for RepeatedSlice<A, I, E, S>
 where
-    I: Input + ?Sized + SliceInput,
+    A: Parser<'a, I, E, S>,
+    I: SliceInput + ?Sized,
     <I as SliceInput>::Slice: 'a,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
 {
     type Output = &'a <I as SliceInput>::Slice;
 

--- a/src/zero_copy/sliced.rs
+++ b/src/zero_copy/sliced.rs
@@ -1,0 +1,101 @@
+use core::marker::PhantomData;
+
+use super::{
+    error::Error,
+    input::{Input, InputRef, SliceInput},
+    internal::{Check, Emit, Mode},
+    Located, PResult, Parser,
+};
+
+pub struct RepeatedSlice<A, I: ?Sized, E = (), S = ()> {
+    pub(crate) parser: A,
+    pub(crate) at_least: usize,
+    pub(crate) at_most: Option<usize>,
+    pub(crate) phantom: PhantomData<(E, S, I)>,
+}
+
+impl<A: Copy, I: ?Sized, E, S> Copy for RepeatedSlice<A, I, E, S> {}
+impl<A: Clone, I: ?Sized, E, S> Clone for RepeatedSlice<A, I, E, S> {
+    fn clone(&self) -> Self {
+        Self {
+            parser: self.parser.clone(),
+            at_least: self.at_least,
+            at_most: self.at_most,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, A: Parser<'a, I, E, S>, I: Input + ?Sized, E: Error<I>, S: 'a> RepeatedSlice<A, I, E, S> {
+    pub fn at_least(self, at_least: usize) -> Self {
+        Self { at_least, ..self }
+    }
+
+    pub fn at_most(self, at_most: usize) -> Self {
+        Self {
+            at_most: Some(at_most),
+            ..self
+        }
+    }
+
+    pub fn exactly(self, exactly: usize) -> Self {
+        Self {
+            at_least: exactly,
+            at_most: Some(exactly),
+            ..self
+        }
+    }
+
+    pub fn collect(self) -> Self
+    where
+        A: Parser<'a, I, E, S>,
+    {
+        Self {
+            parser: self.parser,
+            at_least: self.at_least,
+            at_most: self.at_most,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, I, E, S, A> Parser<'a, I, E, S> for RepeatedSlice<A, I, E, S>
+where
+    I: Input + ?Sized + SliceInput,
+    <I as SliceInput>::Slice: 'a,
+    E: Error<I>,
+    S: 'a,
+    A: Parser<'a, I, E, S>,
+{
+    type Output = &'a <I as SliceInput>::Slice;
+
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+        let mut count = 0;
+        let start = inp.save();
+        loop {
+            let before = inp.save();
+            match self.parser.go::<M>(inp) {
+                Ok(_) => {
+                    count += 1;
+                    if let Some(at_most) = self.at_most {
+                        if count >= at_most {
+                            let now = inp.save();
+                            break Ok(M::bind(|| inp.slice(start..now)));
+                        }
+                    }
+                }
+                Err(e) => {
+                    inp.rewind(before);
+                    break if count >= self.at_least {
+                        let now = inp.save();
+                        break Ok(M::bind(|| inp.slice(start..now)));
+                    } else {
+                        Err(e)
+                    };
+                }
+            }
+        }
+    }
+
+    go_extra!();
+}

--- a/src/zero_copy/sliced.rs
+++ b/src/zero_copy/sliced.rs
@@ -129,12 +129,12 @@ where
     type Output = &'a I::Slice;
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
-        let now = inp.save();
+        let before = inp.save();
         let _a = self.parser_a.go::<M>(inp)?;
         let _b = self.parser_b.go::<M>(inp)?;
         let after = inp.save();
 
-        Ok(M::bind(|| inp.slice(now..after)))
+        Ok(M::bind(|| inp.slice(before..after)))
     }
 
     go_extra!();

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -232,7 +232,7 @@ where
 
 /// A parser that accepts a C-style identifier.
 #[must_use]
-fn ident<'a, I, E, S>() -> impl Parser<'a, I, E, S, Output = &'a I::Slice>
+pub fn ident<'a, I, E, S>() -> impl Parser<'a, I, E, S, Output = &'a I::Slice>
 where
     I: SliceInput + ?Sized,
     I::Token: Char,
@@ -251,7 +251,7 @@ where
 
 /// A parser that accepts a C-style identifier.
 #[must_use]
-fn keyword<'a, I, E, S, K>(word: K) -> impl Parser<'a, I, E, S, Output = ()>
+pub fn keyword<'a, I, E, S, K>(word: K) -> impl Parser<'a, I, E, S, Output = ()>
 where
     I: SliceInput + ?Sized,
     I::Token: Char,

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -187,7 +187,10 @@ where
 #[must_use]
 pub fn digits<'a, I, E, S, C>(
     radix: u32,
-) -> Map<RepeatedSlice<impl Parser<'a, I, E, S, Output = I::Token>, I, E, S>, fn(&'a I::Slice) -> C>
+) -> Map<
+    RepeatedSlice<impl Parser<'a, I, E, S, Output = I::Token> + Copy + Clone, I, E, S>,
+    fn(&'a I::Slice) -> C,
+>
 where
     I: SliceInput + ?Sized,
     I::Token: Char,
@@ -232,7 +235,7 @@ where
 
 /// A parser that accepts a C-style identifier.
 #[must_use]
-pub fn ident<'a, I, E, S>() -> impl Parser<'a, I, E, S, Output = &'a I::Slice>
+pub fn ident<'a, I, E, S>() -> impl Parser<'a, I, E, S, Output = &'a I::Slice> + Clone
 where
     I: SliceInput + ?Sized,
     I::Token: Char,
@@ -251,14 +254,14 @@ where
 
 /// A parser that accepts a C-style identifier.
 #[must_use]
-pub fn keyword<'a, I, E, S, K>(word: K) -> impl Parser<'a, I, E, S, Output = ()>
+pub fn keyword<'a, I, E, S, K>(word: K) -> impl Parser<'a, I, E, S, Output = ()> + Clone
 where
     I: SliceInput + ?Sized,
     I::Token: Char,
     I::Slice: 'a + PartialEq,
     E: Error<I>,
     S: 'a,
-    K: AsRef<I::Slice>,
+    K: AsRef<I::Slice> + Clone,
 {
     ident().try_map(move |s: &I::Slice, span| {
         if s == word.as_ref() {

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -16,6 +16,8 @@ pub trait Char: Sized {
     fn is_whitespace(&self) -> bool;
 
     fn is_digit(&self, radix: u32) -> bool;
+
+    fn is_zero(&self) -> bool;
 }
 
 impl Char for char {
@@ -44,6 +46,10 @@ impl Char for char {
     fn is_digit(&self, radix: u32) -> bool {
         char::is_digit(*self, radix)
     }
+
+    fn is_zero(&self) -> bool {
+        *self == '0'
+    }
 }
 
 impl Char for u8 {
@@ -71,6 +77,10 @@ impl Char for u8 {
 
     fn is_digit(&self, radix: u32) -> bool {
         char::from(*self).is_digit(radix)
+    }
+
+    fn is_zero(&self) -> bool {
+        *self == b'0'
     }
 }
 
@@ -136,6 +146,32 @@ where
         .filter(move |x: &I::Token| x.is_digit(radix))
         .repeated_slice()
         .at_least(1)
+        .map(C::from)
+}
+
+/// A parser that accepts a non-negative integer.
+///
+/// An integer is defined as a non-empty sequence of ASCII digits, where the first digit is non-zero or the sequence
+/// has length one.
+///
+/// The `radix` parameter functions identically to [`char::is_digit`]. If in doubt, choose `10`.
+pub fn int<'a, I, E, S, C>(radix: u32) -> impl Parser<'a, I, E, S, Output = C>
+where
+    I: Input + ?Sized + SliceInput,
+    I::Token: Char,
+    <I as SliceInput>::Slice: 'a,
+    E: Error<I>,
+    S: 'a,
+    C: From<&'a <I as SliceInput>::Slice>,
+{
+    primitive::any()
+        .filter(move |x: &I::Token| x.is_zero())
+        .repeated_slice()
+        .exactly(1)
+        .or(primitive::any()
+            .filter(move |x: &I::Token| x.is_digit(radix))
+            .repeated_slice()
+            .at_least(1))
         .map(C::from)
 }
 
@@ -253,6 +289,63 @@ mod tests {
                 .parse(input);
 
             assert_eq!(res, (Some(vec![123_i32, 456, 789, 000,]), Vec::new()));
+        }
+
+        #[test]
+        fn parses_int() {
+            let res = int::<_, (), (), _>(10).parse("0123456789");
+            assert_eq!(res, (Some("0".to_string()), Vec::new()));
+
+            let res = int::<_, (), (), _>(10).parse("123456789");
+            assert_eq!(res, (Some("123456789".to_string()), Vec::new()));
+        }
+
+        #[test]
+        fn parses_int_into_slice() {
+            let res = int::<_, (), (), _>(10).parse("0123456789");
+            assert_eq!(res, (Some("0"), Vec::new()));
+
+            let res = int::<_, (), (), _>(10).parse("123456789");
+            assert_eq!(res, (Some("123456789"), Vec::new()));
+        }
+
+        #[test]
+        fn parses_int_into_vec() {
+            let res = int::<_, (), (), _>(16).parse("0123456789ABCDEF");
+            assert_eq!(res, (Some(b"0".to_vec()), Vec::new()));
+
+            let res = int::<_, (), (), _>(16).parse("123456789ABCDEF");
+            assert_eq!(res, (Some(b"123456789ABCDEF".to_vec()), Vec::new()));
+        }
+
+        #[test]
+        fn parses_int_from_non_static() {
+            let string = String::from("f123456");
+            let res = int::<_, (), (), _>(7).parse(&string[1..]);
+            assert_eq!(res, (Some("123456"), Vec::new()));
+        }
+
+        #[test]
+        fn int_with_others() {
+            let input = "0 123 456 789 000";
+            let res = int::<_, (), (), &'_ str>(10)
+                .then_ignore(super::prelude::just(' '))
+                .repeated()
+                .collect()
+                .parse(input);
+
+            assert_eq!(res, (Some(vec!["0", "123", "456", "789"]), Vec::new()));
+
+            let input = "0 123 456 789 000";
+            let res = int::<_, (), (), _>(10)
+                .padded()
+                .map(|x: &str| x.parse())
+                .unwrapped()
+                .repeated()
+                .collect()
+                .parse(input);
+
+            assert_eq!(res, (Some(vec![0, 123_i32, 456, 789, 0, 0, 0]), Vec::new()));
         }
     }
 }

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -14,6 +14,8 @@ pub trait Char: Sized {
     fn match_regex(regex: &Self::Regex, trailing: &Self::Slice) -> Option<usize>;
 
     fn is_whitespace(&self) -> bool;
+
+    fn is_digit(&self, radix: u32) -> bool;
 }
 
 impl Char for char {
@@ -38,6 +40,10 @@ impl Char for char {
     fn is_whitespace(&self) -> bool {
         (*self).is_whitespace()
     }
+
+    fn is_digit(&self, radix: u32) -> bool {
+        char::is_digit(*self, radix)
+    }
 }
 
 impl Char for u8 {
@@ -61,6 +67,10 @@ impl Char for u8 {
 
     fn is_whitespace(&self) -> bool {
         self.is_ascii_whitespace()
+    }
+
+    fn is_digit(&self, radix: u32) -> bool {
+        char::from(*self).is_digit(radix)
     }
 }
 
@@ -102,6 +112,31 @@ where
         .ignored()
         .repeated()
         .collect()
+}
+
+/// A parser that accepts one or more ASCII digits.
+///
+/// The `radix` parameter functions identically to [`char::is_digit`]. If in doubt, choose `10`.
+#[must_use]
+pub fn digits<'a, I, E, S, C>(
+    radix: u32,
+) -> Map<
+    RepeatedSlice<impl Parser<'a, I, E, S, Output = I::Token>, I, E, S>,
+    fn(&'a <I as SliceInput>::Slice) -> C,
+>
+where
+    I: Input + ?Sized + SliceInput,
+    I::Token: Char,
+    <I as SliceInput>::Slice: 'a,
+    E: Error<I>,
+    S: 'a,
+    C: From<&'a <I as SliceInput>::Slice>,
+{
+    primitive::any()
+        .filter(move |x: &I::Token| x.is_digit(radix))
+        .repeated_slice()
+        .at_least(1)
+        .map(C::from)
 }
 
 #[cfg(test)]
@@ -166,6 +201,58 @@ mod tests {
             };
 
             assert_eq!(res, (Some(vec![(), (), (), (), (), (), ()]), Vec::new()));
+        }
+    }
+
+    mod numbers {
+        use super::*;
+
+        #[test]
+        fn parses_digits() {
+            let res = digits::<_, (), (), _>(10).parse("0123456789");
+            assert_eq!(res, (Some("0123456789".to_string()), Vec::new()));
+        }
+
+        #[test]
+        fn parses_digits_into_slice() {
+            let res = digits::<_, (), (), _>(10).parse("0123456789");
+            assert_eq!(res, (Some("0123456789"), Vec::new()));
+        }
+
+        #[test]
+        fn parses_digits_into_vec() {
+            let res = digits::<_, (), (), _>(16).parse("0123456789ABCDEF");
+            assert_eq!(res, (Some(b"0123456789ABCDEF".to_vec()), Vec::new()));
+        }
+
+        #[test]
+        fn parses_digits_from_non_static() {
+            let string = String::from("f123456");
+            let res = digits::<_, (), (), _>(7).parse(&string[1..]);
+            assert_eq!(res, (Some("123456"), Vec::new()));
+        }
+
+        #[test]
+        fn digits_with_others() {
+            let input = "123 456 789 000";
+            let res = digits::<_, (), (), _>(10)
+                .padded()
+                .repeated()
+                .collect()
+                .parse(input);
+
+            assert_eq!(res, (Some(vec!["123", "456", "789", "000"]), Vec::new()));
+
+            let input = "123 456 789 000";
+            let res = digits::<_, (), (), _>(10)
+                .padded()
+                .map(|x: &str| x.parse())
+                .unwrapped()
+                .repeated()
+                .collect()
+                .parse(input);
+
+            assert_eq!(res, (Some(vec![123_i32, 456, 789, 000,]), Vec::new()));
         }
     }
 }

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -1,3 +1,5 @@
+use primitive::just;
+
 use super::*;
 
 pub trait Char: Sized {
@@ -123,6 +125,38 @@ where
     primitive::any()
         .filter(|x: &I::Token| x.is_whitespace())
         .repeated()
+        .ignored()
+}
+
+/// A parser that accepts (and ignores) any newline characters or character sequences.
+///
+/// The output type of this parser is `()`.
+///
+/// This parser is quite extensive, recognising:
+///
+/// - Line feed (`\n`)
+/// - Carriage return (`\r`)
+/// - Carriage return + line feed (`\r\n`)
+/// - Vertical tab (`\x0B`)
+/// - Form feed (`\x0C`)
+/// - Next line (`\u{0085}`)
+/// - Line separator (`\u{2028}`)
+/// - Paragraph separator (`\u{2029}`)
+#[must_use]
+pub fn newline<S, E>() -> impl for<'a> Parser<'a, str, E, S, Output = ()>
+where
+    E: Error<str>,
+    for<'a> S: 'a,
+{
+    just('\r')
+        .or_not()
+        .ignore_then(just('\n'))
+        .or(just('\r')) // Carriage return
+        .or(just('\x0B')) // Vertical tab
+        .or(just('\x0C')) // Form feed
+        .or(just('\u{0085}')) // Next line
+        .or(just('\u{2028}')) // Line separator
+        .or(just('\u{2029}')) // Paragraph separator
         .ignored()
 }
 

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -154,6 +154,7 @@ where
 /// has length one.
 ///
 /// The `radix` parameter functions identically to [`char::is_digit`]. If in doubt, choose `10`.
+#[must_use]
 pub fn int<'a, I, E, S, C>(radix: u32) -> impl Parser<'a, I, E, S, Output = C>
 where
     I: SliceInput + ?Sized,

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -139,12 +139,13 @@ pub fn whitespace<I, E, S>() -> impl for<'a> Parser<'a, I, E, S, Output = ()>
 where
     I: SliceInput + ?Sized,
     I::Token: Char,
+    for<'a> I::Slice: 'a,
     E: Error<I>,
     for<'a> S: 'a,
 {
     primitive::any()
         .filter(|x: &I::Token| x.is_whitespace())
-        .repeated()
+        .repeated_slice()
         .ignored()
 }
 

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -109,6 +109,9 @@ where
     go_extra!();
 }
 
+/// A parser that accepts (and ignores) any number of whitespace characters.
+///
+/// The output type of this parser is `()`.
 #[must_use]
 pub fn whitespace<I, E, S>() -> impl for<'a> Parser<'a, I, E, S, Output = ()>
 where

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -186,17 +186,14 @@ where
 #[must_use]
 pub fn digits<'a, I, E, S, C>(
     radix: u32,
-) -> Map<
-    RepeatedSlice<impl Parser<'a, I, E, S, Output = I::Token>, I, E, S>,
-    fn(&'a <I as SliceInput>::Slice) -> C,
->
+) -> Map<RepeatedSlice<impl Parser<'a, I, E, S, Output = I::Token>, I, E, S>, fn(&'a I::Slice) -> C>
 where
     I: SliceInput + ?Sized,
     I::Token: Char,
-    <I as SliceInput>::Slice: 'a,
+    I::Slice: 'a,
     E: Error<I>,
     S: 'a,
-    C: From<&'a <I as SliceInput>::Slice>,
+    C: From<&'a I::Slice>,
 {
     primitive::any()
         .filter(move |x: &I::Token| x.is_digit(radix))
@@ -216,10 +213,10 @@ pub fn int<'a, I, E, S, C>(radix: u32) -> impl Parser<'a, I, E, S, Output = C>
 where
     I: SliceInput + ?Sized,
     I::Token: Char,
-    <I as SliceInput>::Slice: 'a,
+    I::Slice: 'a,
     E: Error<I>,
     S: 'a,
-    C: From<&'a <I as SliceInput>::Slice>,
+    C: From<&'a I::Slice>,
 {
     primitive::any()
         .filter(move |x: &I::Token| x.is_zero())
@@ -234,11 +231,11 @@ where
 
 /// A parser that accepts a C-style identifier.
 #[must_use]
-fn ident<'a, I, E, S>() -> impl Parser<'a, I, E, S, Output = &'a <I as SliceInput>::Slice>
+fn ident<'a, I, E, S>() -> impl Parser<'a, I, E, S, Output = &'a I::Slice>
 where
     I: SliceInput + ?Sized,
     I::Token: Char,
-    <I as SliceInput>::Slice: 'a,
+    I::Slice: 'a,
     E: Error<I>,
     S: 'a,
 {
@@ -257,12 +254,12 @@ fn keyword<'a, I, E, S, K>(word: K) -> impl Parser<'a, I, E, S, Output = ()>
 where
     I: SliceInput + ?Sized,
     I::Token: Char,
-    <I as SliceInput>::Slice: 'a + PartialEq,
+    I::Slice: 'a + PartialEq,
     E: Error<I>,
     S: 'a,
-    K: AsRef<<I as SliceInput>::Slice>,
+    K: AsRef<I::Slice>,
 {
-    ident().try_map(move |s: &<I as SliceInput>::Slice, span| {
+    ident().try_map(move |s: &I::Slice, span| {
         if s == word.as_ref() {
             Ok(())
         } else {

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -110,18 +110,17 @@ where
 }
 
 #[must_use]
-pub fn whitespace<I, E, S>() -> impl for<'a> Parser<'a, I, E, S, Output = Vec<()>>
+pub fn whitespace<I, E, S>() -> impl for<'a> Parser<'a, I, E, S, Output = ()>
 where
-    I: Input + ?Sized,
+    I: SliceInput + ?Sized,
     I::Token: Char,
     E: Error<I>,
     for<'a> S: 'a,
 {
     primitive::any()
         .filter(|x: &I::Token| x.is_whitespace())
-        .ignored()
         .repeated()
-        .collect()
+        .ignored()
 }
 
 /// A parser that accepts one or more ASCII digits.
@@ -185,13 +184,13 @@ mod tests {
         #[test]
         fn parses_whitespace() {
             let res = whitespace::<_, (), ()>().parse(" \x09\x0A\x0B\x0C\x0D");
-            assert_eq!(res, (Some(vec![(), (), (), (), (), ()]), Vec::new()));
+            assert_eq!(res, (Some(()), Vec::new()));
         }
 
         #[test]
         fn parses_whitespace_stops_on_non() {
             let res = whitespace::<_, (), ()>().parse("\x09\x0A f \x0B\x0C\x0D");
-            assert_eq!(res, (Some(vec![(), (), ()]), Vec::new()));
+            assert_eq!(res, (Some(()), Vec::new()));
         }
 
         #[test]
@@ -201,7 +200,7 @@ mod tests {
                 whitespace::<_, (), ()>().parse(&*a)
             };
 
-            assert_eq!(res, (Some(vec![(), (), (), (), (), (), ()]), Vec::new()));
+            assert_eq!(res, (Some(()), Vec::new()));
         }
 
         #[test]
@@ -209,24 +208,24 @@ mod tests {
             // '\x0B' is classified as unicode whitespace, but not ascii-whitespace,
             // so it is NOT counted as whitespace for this test
             let res = whitespace::<_, (), ()>().parse(" \x09\x0A\x0B\x0C\x0D".as_bytes());
-            assert_eq!(res, (Some(vec![(), (), ()]), Vec::new()));
+            assert_eq!(res, (Some(()), Vec::new()));
 
             let res = whitespace::<_, (), ()>().parse("\x0C\x0D".as_bytes());
-            assert_eq!(res, (Some(vec![(), ()]), Vec::new()));
+            assert_eq!(res, (Some(()), Vec::new()));
         }
 
         #[test]
         fn parses_whitespace_bytes_stops_at_non() {
             let res = whitespace::<_, (), ()>().parse(b"\x09\x0Af\x0B\x0C\x0D".as_slice());
-            assert_eq!(res, (Some(vec![(), ()]), Vec::new()));
+            assert_eq!(res, (Some(()), Vec::new()));
 
             // '\x0B' is classified as unicode whitespace, but not ascii-whitespace,
             // so it is NOT counted as whitespace for this test
             let res = whitespace::<_, (), ()>().parse(b"\x0B\x0C\x0D".as_slice());
-            assert_eq!(res, (Some(vec![]), Vec::new()));
+            assert_eq!(res, (Some(()), Vec::new()));
 
             let res = whitespace::<_, (), ()>().parse(b"\x0C\x0D".as_slice());
-            assert_eq!(res, (Some(vec![(), ()]), Vec::new()));
+            assert_eq!(res, (Some(()), Vec::new()));
         }
 
         #[test]
@@ -236,7 +235,7 @@ mod tests {
                 whitespace::<_, (), ()>().parse(a.as_bytes())
             };
 
-            assert_eq!(res, (Some(vec![(), (), (), (), (), (), ()]), Vec::new()));
+            assert_eq!(res, (Some(()), Vec::new()));
         }
     }
 

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -135,7 +135,7 @@ pub fn digits<'a, I, E, S, C>(
     fn(&'a <I as SliceInput>::Slice) -> C,
 >
 where
-    I: Input + ?Sized + SliceInput,
+    I: SliceInput + ?Sized,
     I::Token: Char,
     <I as SliceInput>::Slice: 'a,
     E: Error<I>,
@@ -157,7 +157,7 @@ where
 /// The `radix` parameter functions identically to [`char::is_digit`]. If in doubt, choose `10`.
 pub fn int<'a, I, E, S, C>(radix: u32) -> impl Parser<'a, I, E, S, Output = C>
 where
-    I: Input + ?Sized + SliceInput,
+    I: SliceInput + ?Sized,
     I::Token: Char,
     <I as SliceInput>::Slice: 'a,
     E: Error<I>,


### PR DESCRIPTION
Here is a quick rundown of the changes:

- Additions:
    - `zero_copy::text::whitespace`
    - `zero_copy::text::newline`
    - `zero_copy::text::digits`
    - `zero_copy::text::int`
    - `zero_copy::text::ident`
    - `zero_copy::text::keyword`
    - `zero_copy::Parser::repeated_slice`
    - `zero_copy::Parser::then_slice`
    - `zero_copy::sliced`
    - `zero_copy::sliced::RepeatedSlice`
    - `zero_copy::sliced::ThenSlice`
    - `zero_copy::text::Char::is_valid_ident_start`
    - `zero_copy::text::Char::is_valid_ident_continue`
    - `zero_copy::text::Char::is_digit`
    - `zero_copy::text::Char::is_zero`

Here are some notes that I took while going through this:

- All of the parsers should have the same parsing capability as on the `master` branch, with slightly more return value flexibility.
- I wasn't really sure if the `_slice` methods that I added to `Parser` should be part of another trait or not. 
- The user still has the same amount of flexibility with `digits` and `int`, though they may have to use an extra `map`. They both still work with `Parser::from_str` as they did on `master`!

If there is anything you find odd, or that looks like it could use improvement, please do let me know! Thanks in advance!