### PR TITLE
Random `zero-copy` fixes!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "chumsky"
 version = "0.8.0"
 description = "A parser library for humans with powerful error recovery"
-authors = ["Joshua Barretto <joshua.s.barretto@gmail.com>"]
+authors = ["Joshua Barretto <joshua.s.barretto@gmail.com>", "Elijah Hartvigsen <elijah.reed@hartvigsen.xyz"]
 repository = "https://github.com/zesterer/chumsky"
 license = "MIT"
 keywords = ["parser", "combinator", "token", "language", "syntax"]

--- a/src/zero_copy/input.rs
+++ b/src/zero_copy/input.rs
@@ -35,8 +35,17 @@ impl Input for str {
     }
 
     fn next(&self, offset: Self::Offset) -> (Self::Offset, Option<Self::Token>) {
-        let chr = unsafe { self.get_unchecked(offset..).chars().next() };
-        (offset + chr.map_or(0, char::len_utf8), chr)
+        if offset < self.len() {
+            let c = unsafe {
+                self.get_unchecked(offset..)
+                    .chars()
+                    .next()
+                    .unwrap_unchecked()
+            };
+            (offset + c.len_utf8(), Some(c))
+        } else {
+            (offset, None)
+        }
     }
 
     fn span(&self, range: Range<Self::Offset>) -> Self::Span {

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -379,7 +379,7 @@ where
     }
 }
 
-impl<'a, P, I, E, S, C> Parser<'a, I, E, S> for TakeUntil<P, C>
+impl<'a, P, I, E, S, C> Parser<'a, I, E, S> for TakeUntil<P, I, C, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,


### PR DESCRIPTION
While I was moving my lexer over to `zero-copy` there were some issues that I encountered related to `TakeUntil`, and I am sad to say it took like an hour and a half of dealing with Rusts wonderful generic errors before I was able to find the reason why.

The current implementation for of `Parser` is only implemented  for `TakeUntil<P, C>`, and when one fills in the missing items, you get: `TakeUntil<P, C, (), (), ()>`. This was a particularly fun problem because `C`, which represents the collection that should be parsed into, is actually in the spot for the input generic `I`, which we can see when we look at the definition here `pub struct TakeUntil<P, I: ?Sized, C = (), E = (), S = ()>`

Additionally I fixed the bug that I accidentally introduced in one of my previous pull requests. At the time I believed it to be correct, and have gotten one less branch. What I didn't realize was that I removed the branch that assured that the `offset` index is within the `&str`. By removing that I enabled the classic "read memory that doesn't belong to you" bug.