### PR TITLE
Add unit tests for `Simple` `Display` output; improve either/or wording.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,6 @@ stacker = { version = "0.1", optional = true }
 
 [dev-dependencies]
 ariadne = "0.1.2"
+indoc = "1.0.7"
 pom = "3.0"
+test-case = "2.2.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -473,3 +473,6 @@ pub(crate) fn merge_alts<I, E: Error<I>, T: IntoIterator<Item = Located<I, E>>>(
     }
     error
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/error.rs
+++ b/src/error.rs
@@ -323,12 +323,6 @@ impl<I: fmt::Display + Hash + Eq, S: Span> fmt::Display for Simple<I, S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // TODO: Take `self.reason` into account
 
-        if let Some(found) = &self.found {
-            write!(f, "found {:?}", found.to_string())?;
-        } else {
-            write!(f, "found end of input")?;
-        };
-
         // Describe expected tokens consistently in each case:
         fn describe_expected<I>(exp: &Option<I>) -> String
         where
@@ -339,6 +333,8 @@ impl<I: fmt::Display + Hash + Eq, S: Span> fmt::Display for Simple<I, S> {
                 None => "end of input".to_string(),
             }
         }
+
+        write!(f, "found {}", describe_expected(&self.found))?;
 
         match self.expected.len() {
             0 => {} //write!(f, " but end of input was expected")?,

--- a/src/error.rs
+++ b/src/error.rs
@@ -343,14 +343,21 @@ impl<I: fmt::Display + Hash + Eq, S: Span> fmt::Display for Simple<I, S> {
                 write!(
                     f,
                     " but expected one of {}",
-                    self.expected
-                        .iter()
-                        .map(|expected| match expected {
-                            Some(x) => format!("{:?}", x.to_string()),
-                            None => "end of input".to_string(),
-                        })
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    {
+                        // Sort `expected` for stable error messages:
+                        let mut v: Vec<_> = self
+                            .expected
+                            .iter()
+                            .map(|expected| match expected {
+                                Some(x) => format!("{:?}", x.to_string()),
+                                None => "end of input".to_string(),
+                            })
+                            .collect();
+
+                        v.sort();
+                        v
+                    }
+                    .join(", ")
                 )?;
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -182,6 +182,10 @@ impl<I: fmt::Display, S: fmt::Display> fmt::Display for SimpleReason<I, S> {
 
 /// A simple default error type that tracks error spans, expected inputs, and the actual input found at an error site.
 ///
+/// The [std::fmt::Display] implementation presents expected tokens in a sorted fashion to provide
+/// stable error message strings to avoid user confusion and facilitate deterministic testing of
+/// parse error messages.
+///
 /// Please note that it uses a [`HashSet`] to remember expected symbols. If you find this to be too slow, you can
 /// implement [`Error`] for your own error type or use [`Cheap`] instead.
 #[derive(Clone, Debug)]

--- a/src/error/tests.rs
+++ b/src/error/tests.rs
@@ -1,0 +1,76 @@
+use crate::error::Simple;
+use crate::error::SimpleReason::*;
+use indoc::indoc;
+use std::collections::HashSet;
+use test_case::test_case;
+
+#[test_case(
+    Simple {
+        span: 0..0,
+        reason: Unexpected,
+        expected: HashSet::default(),
+        found: None,
+        label: None,
+    }
+    => indoc! {
+        r#"
+        found end of input
+        "#
+    }.trim_end().to_string()
+)]
+#[test_case(
+    Simple {
+        span: 0..0,
+        reason: Unclosed {
+            span: 0..0,
+            delimiter: '(',
+        },
+        expected: HashSet::default(),
+        found: None,
+        label: None,
+    }
+    => indoc! {
+        r#"
+        found end of input
+        "#
+    }.trim_end().to_string()
+)]
+#[test_case(
+    Simple {
+        span: 0..0,
+        reason: Custom("CUSTOM_ERROR".to_string()),
+        expected: HashSet::default(),
+        found: None,
+        label: None,
+    }
+    => indoc! {
+        r#"
+        found end of input
+        "#
+    }.trim_end().to_string()
+)]
+#[test_case(
+    Simple {
+        span: 0..0,
+        reason: Unexpected,
+        expected: make_expected(['x', 'y']),
+        found: None,
+        label: None,
+    }
+    => indoc! {
+        r#"
+        found end of input but expected one of "x", "y"
+        "#
+    }.trim_end().to_string()
+)]
+fn error_display(s: Simple<char>) -> String {
+    s.to_string()
+}
+
+fn make_expected<I, T>(alternatives: I) -> HashSet<Option<char>, crate::error::RandomState>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<Option<char>>,
+{
+    alternatives.into_iter().map(|x| x.into()).collect()
+}


### PR DESCRIPTION
This PR includes 4 improvements:

- It adds unit tests for the `Display` of `Simple` and tests a variety of `Simple<char>` display cases.
- It sorts the display of `expected` tokens, so that they are stable in UIs and to facilitate parse error messages testing.
- It changes `expected` display of a pair from `one of "x", "y"` to `either "x" or "y"`.
- It changes `expected` display of three or more from `one of "x", "y", "z"` to `one of "x", "y", or "z"`.

Note that this includes a test case for custom errors, and asserts that the display is `found end of input` even though this is a bug! A potential future branch fixing that bug needs to update that test case appropriately.