### PR TITLE
zero-copy: several things

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,17 @@ nightly = []
 spill-stack = ["stacker", "std"]
 
 [dependencies]
-hashbrown = "0.11"
+hashbrown = "0.12"
 stacker = { version = "0.1", optional = true }
 # Enables regex combinators
-regex = { version = "1.5", optional = true }
+regex = { version = "1.6", optional = true }
 
 [dev-dependencies]
 ariadne = "0.1.2"
-pom = "3.0"
+pom = "3.2"
 nom = "7.1"
 serde_json = { version = "1.0", features = ["preserve_order"] }
-criterion = "0.3.5"
+criterion = "0.4.0"
 
 [[bench]]
 name = "json"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
     feature(
         rustc_attrs,
         bench_black_box,
-        generic_associated_types,
         maybe_uninit_uninit_array,
         maybe_uninit_array_assume_init,
         once_cell,

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -26,7 +26,7 @@ pub mod text;
 pub mod prelude {
     pub use super::{
         error::{Error as _, Rich, Simple},
-        primitive::{any, choice, empty, end, just, none_of, one_of, take_until, todo},
+        primitive::{any, choice, empty, end, group, just, none_of, one_of, take_until, todo},
         // recovery::{nested_delimiters, skip_then_retry_until, skip_until},
         recursive::{recursive, Recursive},
         // select,

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -757,6 +757,46 @@ fn zero_copy_repetition() {
     assert!(!parser().parse("[3, 4, 5, 67 89,]").1.is_empty());
 }
 
+#[test]
+fn zero_copy_group() {
+    use self::prelude::*;
+
+    fn parser<'a>() -> impl Parser<'a, str, Output = (&'a str, u64, char)> {
+        group((
+            any()
+                .filter(|c: &char| c.is_ascii_alphabetic())
+                .repeated()
+                .at_least(1)
+                .map_slice(|s: &str| s)
+                .padded(),
+            any()
+                .filter(|c: &char| c.is_ascii_digit())
+                .repeated()
+                .at_least(1)
+                .map_slice(|s: &str| s.parse::<u64>().unwrap())
+                .padded(),
+            any().filter(|c: &char| !c.is_whitespace()).padded(),
+        ))
+    }
+
+    assert_eq!(
+        parser().parse("abc 123 ["),
+        (Some(("abc", 123, '[')), Vec::new())
+    );
+    assert_eq!(
+        parser().parse("among3d"),
+        (Some(("among", 3, 'd')), Vec::new())
+    );
+    assert_eq!(
+        parser().parse("cba321,"),
+        (Some(("cba", 321, ',')), Vec::new())
+    );
+
+    assert!(!parser().parse("abc 123  ").1.is_empty());
+    assert!(!parser().parse("123abc ]").1.is_empty());
+    assert!(!parser().parse("and one &").1.is_empty());
+}
+
 #[cfg(feature = "regex")]
 #[test]
 fn regex_parser() {

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub struct End<I: ?Sized>(PhantomData<I>);
 
-pub fn end<I: Input + ?Sized>() -> End<I> {
+pub const fn end<I: Input + ?Sized>() -> End<I> {
     End(PhantomData)
 }
 
@@ -37,7 +37,7 @@ where
 
 pub struct Empty<I: ?Sized>(PhantomData<I>);
 
-pub fn empty<I: Input + ?Sized>() -> Empty<I> {
+pub const fn empty<I: Input + ?Sized>() -> Empty<I> {
     Empty(PhantomData)
 }
 
@@ -144,7 +144,7 @@ impl<T: Clone, I: ?Sized, E, S> Clone for Just<T, I, E, S> {
     }
 }
 
-pub fn just<T, I, E, S>(seq: T) -> Just<T, I, E, S>
+pub const fn just<T, I, E, S>(seq: T) -> Just<T, I, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -206,7 +206,7 @@ impl<T: Clone, I: ?Sized, E, S> Clone for OneOf<T, I, E, S> {
     }
 }
 
-pub fn one_of<T, I, E, S>(seq: T) -> OneOf<T, I, E, S>
+pub const fn one_of<T, I, E, S>(seq: T) -> OneOf<T, I, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -258,7 +258,7 @@ impl<T: Clone, I: ?Sized, E, S> Clone for NoneOf<T, I, E, S> {
     }
 }
 
-pub fn none_of<T, I, E, S>(seq: T) -> NoneOf<T, I, E, S>
+pub const fn none_of<T, I, E, S>(seq: T) -> NoneOf<T, I, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -330,7 +330,7 @@ where
     go_extra!();
 }
 
-pub fn any<I: Input + ?Sized, E: Error<I>, S>() -> Any<I, E, S> {
+pub const fn any<I: Input + ?Sized, E: Error<I>, S>() -> Any<I, E, S> {
     Any {
         phantom: PhantomData,
     }
@@ -366,7 +366,7 @@ impl<P: Clone, I: ?Sized, C, E, S> Clone for TakeUntil<P, I, C, E, S> {
     }
 }
 
-pub fn take_until<'a, P, I, E, S>(until: P) -> TakeUntil<P, I, (), E, S>
+pub const fn take_until<'a, P, I, E, S>(until: P) -> TakeUntil<P, I, (), E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -425,7 +425,7 @@ impl<I: ?Sized, E> Clone for Todo<I, E> {
     }
 }
 
-pub fn todo<I: Input + ?Sized, E: Error<I>>() -> Todo<I, E> {
+pub const fn todo<I: Input + ?Sized, E: Error<I>>() -> Todo<I, E> {
     Todo(PhantomData)
 }
 
@@ -443,14 +443,22 @@ where
 
     go_extra!();
 }
-
-#[derive(Copy, Clone)]
 pub struct Choice<T, O> {
     parsers: T,
     phantom: PhantomData<O>,
 }
 
-pub fn choice<T, O>(parsers: T) -> Choice<T, O> {
+impl<T: Copy, O> Copy for Choice<T, O> {}
+impl<T: Clone, O> Clone for Choice<T, O> {
+    fn clone(&self) -> Self {
+        Self {
+            parsers: self.parsers.clone(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+pub const fn choice<T, O>(parsers: T) -> Choice<T, O> {
     Choice {
         parsers,
         phantom: PhantomData,

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -443,6 +443,7 @@ where
 
     go_extra!();
 }
+
 pub struct Choice<T, O> {
     parsers: T,
     phantom: PhantomData<O>,

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -569,18 +569,10 @@ macro_rules! impl_group_for_tuple {
             type Output = ($($X::Output,)*);
 
             fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
-                let before = inp.save();
-
                 let Group { parsers: ($($X,)*) } = self;
 
                 $(
-                    let $X = match $X.go::<M>(inp) {
-                        Ok(out) => out,
-                        Err(e) => {
-                            inp.rewind(before);
-                            return Err(e);
-                        }
-                    };
+                    let $X = $X.go::<M>(inp)?;
                 )*
 
                 Ok(flatten_map!(<M> $($X)*))

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -522,14 +522,15 @@ pub const fn group<T>(parsers: T) -> Group<T> {
     Group { parsers }
 }
 
-// recursively combine to flatten a tuple
-macro_rules! recursive_combine {
+macro_rules! flatten_map {
+    // map a single element into a 1-tuple
     (<$M:ident> $head:ident) => {
         $M::map(
             $head,
             |$head| ($head,),
         )
     };
+    // combine two elements into a 2-tuple
     (<$M:ident> $head1:ident $head2:ident) => {
         $M::combine(
             $head1,
@@ -537,10 +538,11 @@ macro_rules! recursive_combine {
             |$head1, $head2| ($head1, $head2),
         )
     };
+    // combine and flatten n-tuples from recursion
     (<$M:ident> $head:ident $($X:ident)+) => {
         $M::combine(
             $head,
-            recursive_combine!(
+            flatten_map!(
                 <$M>
                 $($X)+
             ),
@@ -581,7 +583,7 @@ macro_rules! impl_group_for_tuple {
                     };
                 )*
 
-                Ok(recursive_combine!(<M> $($X)*))
+                Ok(flatten_map!(<M> $($X)*))
             }
 
             go_extra!();


### PR DESCRIPTION
Changes:
- Remove the `generic_associated_types` feature as it's stable on nightly
- `const`-ify primitive creation functions
  - Closes #194
- Add the `Group` primitive (name ideas welcome!)
  - Minimally tested, may need work
  - Not yet sure how runtime/compiletime performance compares to `then` chains
  - `group` is to `then` as `choice` is to `or`
  - Closes #199
- Bump dependencies
  - `hashbrown`: 0.11 -> 0.12
  - `regex`: 1.5 -> 1.6
  - `pom`: 3.0 -> 3.2
  - `criterion`: 0.3.5 -> 0.4
- Also explicitly implement `Copy` + `Clone` for `Choice` to handle cases where the output type is not