### PR TITLE
`Parser::then_not` for an equivalent of PEG `!`

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -16,6 +16,10 @@ pub type IgnoreThen<A, B, O, U> = Map<Then<A, B>, fn((O, U)) -> U, (O, U)>;
 /// See [`Parser::then_ignore`].
 pub type ThenIgnore<A, B, O, U> = Map<Then<A, B>, fn((O, U)) -> O, (O, U)>;
 
+/// See [`Parser::then_not`].
+pub type ThenNot<A, B, I, O, U, E> =
+    ThenIgnore<A, Rewind<Or<Map<Not<B, U>, fn(I), I>, End<E>>>, O, ()>;
+
 /// See [`Parser::or`].
 #[must_use]
 #[derive(Copy, Clone)]
@@ -1343,7 +1347,7 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, F: Fn(E) -> Result<O, E>, E: Error
                 Ok(out) => {
                     stream.revert(start);
                     Ok((out, None))
-                },
+                }
             },
         };
 


### PR DESCRIPTION
When trying to convert a grammar I wrote in PEG into chumsky, I had a lot of trouble translating PEG `!`.

`Parser::not` which was added recently seems at first the solution, but it has the caveat of parsing a 1 input when the pattern fails to parse. This thus cause issues if we're at the end of the text, and require the usage of `then_ignore`, `rewind`, `end`, `or`, and even `map` to make to make the output of `end` `()` match the output of `not` `I`.

I thus suggest a new combinator `then_not` that wraps all of this, such that PEG `a !b` can be translated to `a.then_not(b)`.

Additionally, it might be useful for users to have a small section about the equivalence between PEG operators and chumsky combinators, as the documentation says "chumsky’s parsers are recursive descent parsers and are capable of parsing parsing expression grammars (PEGs)" but doesn't give more details.