### PR TITLE
zero-copy: add `and_is` and `not` combinators

### DIFF
--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -971,7 +971,7 @@ where
     S: 'a,
     A: Parser<'a, I, E, S>,
 {
-    type Output = I::Token;
+    type Output = ();
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
         let before = inp.save();
@@ -979,22 +979,15 @@ where
         let result = self.parser.go::<Check>(inp);
         inp.rewind(before);
 
-        let (at, tok) = inp.next();
         match result {
-            Ok(_) => Err(Located::at(
-                at,
-                E::expected_found(None, tok, inp.span_since(before)),
-            )),
-            Err(_) => {
-                if let Some(tok) = tok {
-                    Ok(M::bind(|| tok))
-                } else {
-                    Err(Located::at(
-                        at,
-                        E::expected_found(None, None, inp.span_since(before)),
-                    ))
-                }
+            Ok(_) => {
+                let (at, tok) = inp.next();
+                Err(Located::at(
+                    at,
+                    E::expected_found(None, tok, inp.span_since(before)),
+                ))
             }
+            Err(_) => Ok(M::bind(|| ())),
         }
     }
 

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -959,6 +959,96 @@ where
     go_extra!();
 }
 
+#[derive(Copy, Clone)]
+pub struct Not<A> {
+    pub(crate) parser: A,
+}
+
+impl<'a, I, E, S, A> Parser<'a, I, E, S> for Not<A>
+where
+    I: Input + ?Sized,
+    E: Error<I>,
+    S: 'a,
+    A: Parser<'a, I, E, S>,
+{
+    type Output = I::Token;
+
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+        let before = inp.save();
+
+        let result = self.parser.go::<Check>(inp);
+        inp.rewind(before);
+
+        let (at, tok) = inp.next();
+        match result {
+            Ok(_) => Err(Located::at(
+                at,
+                E::expected_found(None, tok, inp.span_since(before)),
+            )),
+            Err(_) => {
+                if let Some(tok) = tok {
+                    Ok(M::bind(|| tok))
+                } else {
+                    Err(Located::at(
+                        at,
+                        E::expected_found(None, None, inp.span_since(before)),
+                    ))
+                }
+            }
+        }
+    }
+
+    go_extra!();
+}
+
+#[derive(Copy, Clone)]
+pub struct AndIs<A, B> {
+    pub(crate) parser_a: A,
+    pub(crate) parser_b: B,
+}
+
+impl<'a, I, E, S, A, B> Parser<'a, I, E, S> for AndIs<A, B>
+where
+    I: Input + ?Sized,
+    E: Error<I>,
+    S: 'a,
+    A: Parser<'a, I, E, S>,
+    B: Parser<'a, I, E, S>,
+{
+    type Output = A::Output;
+
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+        let before = inp.save();
+        match self.parser_a.go::<M>(inp) {
+            Ok(out) => {
+                // A succeeded -- go back to the beginning and try B
+                let after = inp.save();
+                inp.rewind(before);
+
+                match self.parser_b.go::<Check>(inp) {
+                    Ok(_) => {
+                        // B succeeded -- go to the end of A and return its output
+                        inp.rewind(after);
+                        Ok(out)
+                    }
+                    Err(e) => {
+                        // B failed -- go back to the beginning and fail
+                        inp.rewind(before);
+                        Err(e)
+                    }
+                }
+            }
+            Err(e) => {
+                // A failed -- go back to the beginning and fail
+                inp.rewind(before);
+                Err(e)
+            }
+        }
+    }
+
+    go_extra!();
+}
+
 pub trait ContainerExactly<T, const N: usize> {
     type Uninit;
     fn uninit() -> Self::Uninit;

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -448,8 +448,8 @@ pub trait Parser<'a, I: Input + ?Sized, E: Error<I> = (), S: 'a = ()> {
     ///
     /// // Arbitrary text, nested in a tree with { ... } delimiters
     /// let tree = recursive::<_, Simple<str>, (), _, _>(|tree| {
-    ///     let text = one_of("{}")
-    ///         .not()
+    ///     let text = any()
+    ///         .and_is(one_of("{}").not())
     ///         .repeated()
     ///         .at_least(1)
     ///         .map_slice(Tree::Text);


### PR DESCRIPTION
I've been putting this PR off for a little while out of concern for what I thought was strange error behavior:
```sh
# Using code from the "tree" example for `not`
> {{{{
[found '{' at 1..2]
> {{{{}
[found '{' at 1..2]
> {{{{}}
[found '{' at 1..2]
> {{{{}}}
[found end of input at 7..7]
# Wouldn't the first three make more sense if they were similar "end of input" errors?
```
However, this also happens when `none_of("{}")` is used instead of `one_of("{}").not()`, so it's not a problem unique to `not` itself.

I got the errors I expected on master:
```sh
> {{{{
found end of input but expected one of "{", "}"
> {{{{}
found end of input but expected one of "}", "{"
# ...etc
```
so I assume it may related to the differences in error handling between the two branches.

Also, I went ahead and ported `not`'s example and wrote one for `and_is`.