### PR TITLE
[TRY] Change zero_copy::Parser to take output type as generic type

### DIFF
--- a/examples/zero-copy.rs
+++ b/examples/zero-copy.rs
@@ -1,6 +1,6 @@
 use chumsky::zero_copy::prelude::*;
 
-fn parser() -> impl for<'a> Parser<'a, str, Rich<str>, Output = char> {
+fn parser() -> impl for<'a> Parser<'a, str, char, Rich<str>> {
     just('a').or(just('b'))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
 #![deny(missing_docs)]
 #![allow(deprecated)] // TODO: Don't allow this
 
-#![feature(associated_type_defaults)] // TODO: remove when removing 'type Output = O'
-
 extern crate alloc;
 
 pub mod chain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 #![deny(missing_docs)]
 #![allow(deprecated)] // TODO: Don't allow this
 
+#![feature(associated_type_defaults)] // TODO: remove when removing 'type Output = O'
+
 extern crate alloc;
 
 pub mod chain;

--- a/src/zero_copy/blanket.rs
+++ b/src/zero_copy/blanket.rs
@@ -1,14 +1,12 @@
 use super::*;
 
-impl<'a, T, I, E, S> Parser<'a, I, E, S> for &'a T
+impl<'a, T, I, O, E, S> Parser<'a, I, O, E, S> for &'a T
 where
-    T: Parser<'a, I, E, S>,
+    T: Parser<'a, I, O, E, S>,
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
 {
-    type Output = T::Output;
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E>
     where
         Self: Sized,

--- a/src/zero_copy/blanket.rs
+++ b/src/zero_copy/blanket.rs
@@ -7,12 +7,12 @@ where
     E: Error<I>,
     S: 'a,
 {
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E>
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E>
     where
         Self: Sized,
     {
         (*self).go::<M>(inp)
     }
 
-    go_extra!();
+    go_extra!(O);
 }

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -1213,7 +1213,7 @@ where
                         }
 
                         // SAFETY: All entries with an index < i are filled
-                        break Ok(M::array::<A::Output, N>(unsafe {
+                        break Ok(M::array::<OA, N>(unsafe {
                             MaybeUninit::array_assume_init(output)
                         }));
                     } else {

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -479,14 +479,12 @@ where
 }
 
 #[derive(Copy, Clone)]
-pub struct Or<A, B, O> {
+pub struct Or<A, B> {
     pub(crate) parser_a: A,
     pub(crate) parser_b: B,
-    // FIXME try remove O? See comment in Map declaration
-    pub(crate) phantom: PhantomData<O>,
 }
 
-impl<'a, I, O, E, S, A, B> Parser<'a, I, O, E, S> for Or<A, B, O>
+impl<'a, I, O, E, S, A, B> Parser<'a, I, O, E, S> for Or<A, B>
 where
     I: Input + ?Sized,
     E: Error<I>,

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -84,7 +84,7 @@ where
 pub struct Map<A, OA, F> {
     pub(crate) parser: A,
     pub(crate) mapper: F,
-    // FIXME: try remote 'OA' type parameter?
+    // FIXME: try remove 'OA' type parameter?
     // This phantom seems necessary to have OA as part of impl<.., OA>.
     // Otherwise it looks like: impl<.., OA> Parser<..> for Map<A, F>
     // and I get the error [E0207]:
@@ -230,14 +230,15 @@ where
     go_extra!();
 }
 
-pub struct To<A, O, E = (), S = ()> {
+pub struct To<A, OA, O, E = (), S = ()> {
     pub(crate) parser: A,
     pub(crate) to: O,
-    pub(crate) phantom: PhantomData<(E, S)>,
+    // FIXME try remove OA? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OA, E, S)>,
 }
 
-impl<A: Copy, O: Copy, E, S> Copy for To<A, O, E, S> {}
-impl<A: Clone, O: Clone, E, S> Clone for To<A, O, E, S> {
+impl<A: Copy, OA, O: Copy, E, S> Copy for To<A, OA, O, E, S> {}
+impl<A: Clone, OA, O: Clone, E, S> Clone for To<A, OA, O, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser: self.parser.clone(),
@@ -247,17 +248,15 @@ impl<A: Clone, O: Clone, E, S> Clone for To<A, O, E, S> {
     }
 }
 
-impl<'a, I, E, S, A, O> Parser<'a, I, E, S> for To<A, O, E, S>
+impl<'a, I, O, E, S, A, OA> Parser<'a, I, O, E, S> for To<A, OA, O, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
+    A: Parser<'a, I, OA, E, S>,
     O: Clone,
 {
-    type Output = O;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E> {
         self.parser
             .go::<Check>(inp)
             .map(|_| M::bind(|| self.to.clone()))
@@ -266,16 +265,17 @@ where
     go_extra!();
 }
 
-pub type Ignored<A, E = (), S = ()> = To<A, (), E, S>;
+pub type Ignored<A, OA, E = (), S = ()> = To<A, OA, (), E, S>;
 
-pub struct Then<A, B, E = (), S = ()> {
+pub struct Then<A, B, OA, OB, E = (), S = ()> {
     pub(crate) parser_a: A,
     pub(crate) parser_b: B,
-    pub(crate) phantom: PhantomData<(E, S)>,
+    // FIXME try remove OA, OB? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OA, OB, E, S)>,
 }
 
-impl<A: Copy, B: Copy, E, S> Copy for Then<A, B, E, S> {}
-impl<A: Clone, B: Clone, E, S> Clone for Then<A, B, E, S> {
+impl<A: Copy, B: Copy, OA, OB, E, S> Copy for Then<A, B, OA, OB, E, S> {}
+impl<A: Clone, B: Clone, OA, OB, E, S> Clone for Then<A, B, OA, OB, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser_a: self.parser_a.clone(),
@@ -285,33 +285,32 @@ impl<A: Clone, B: Clone, E, S> Clone for Then<A, B, E, S> {
     }
 }
 
-impl<'a, I, E, S, A, B> Parser<'a, I, E, S> for Then<A, B, E, S>
+impl<'a, I, O, E, S, A, B, OA, OB> Parser<'a, I, O, E, S> for Then<A, B, OA, OB, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    B: Parser<'a, I, E, S>,
+    A: Parser<'a, I, OA, E, S>,
+    B: Parser<'a, I, OB, E, S>,
 {
-    type Output = (A::Output, B::Output);
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, (OA, OB), E> {
         let a = self.parser_a.go::<M>(inp)?;
         let b = self.parser_b.go::<M>(inp)?;
-        Ok(M::combine(a, b, |a: A::Output, b: B::Output| (a, b)))
+        Ok(M::combine(a, b, |a: OA, b: OB| (a, b)))
     }
 
     go_extra!();
 }
 
-pub struct IgnoreThen<A, B, E = (), S = ()> {
+pub struct IgnoreThen<A, B, OA, OB, E = (), S = ()> {
     pub(crate) parser_a: A,
     pub(crate) parser_b: B,
-    pub(crate) phantom: PhantomData<(E, S)>,
+    // FIXME try remove OA, OB? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OA, OB, E, S)>,
 }
 
-impl<A: Copy, B: Copy, E, S> Copy for IgnoreThen<A, B, E, S> {}
-impl<A: Clone, B: Clone, E, S> Clone for IgnoreThen<A, B, E, S> {
+impl<A: Copy, B: Copy, OA, OB, E, S> Copy for IgnoreThen<A, B, OA, OB, E, S> {}
+impl<A: Clone, B: Clone, OA, OB, E, S> Clone for IgnoreThen<A, B, OA, OB, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser_a: self.parser_a.clone(),
@@ -321,33 +320,32 @@ impl<A: Clone, B: Clone, E, S> Clone for IgnoreThen<A, B, E, S> {
     }
 }
 
-impl<'a, I, E, S, A, B> Parser<'a, I, E, S> for IgnoreThen<A, B, E, S>
+impl<'a, I, O, E, S, A, B, OA, OB> Parser<'a, I, O, E, S> for IgnoreThen<A, B, OA, OB, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    B: Parser<'a, I, E, S>,
+    A: Parser<'a, I, OA, E, S>,
+    B: Parser<'a, I, OB, E, S>,
 {
-    type Output = B::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, OB, E> {
         let _a = self.parser_a.go::<Check>(inp)?;
         let b = self.parser_b.go::<M>(inp)?;
-        Ok(M::map(b, |b: B::Output| b))
+        Ok(M::map(b, |b: OB| b))
     }
 
     go_extra!();
 }
 
-pub struct ThenIgnore<A, B, E = (), S = ()> {
+pub struct ThenIgnore<A, B, OA, OB, E = (), S = ()> {
     pub(crate) parser_a: A,
     pub(crate) parser_b: B,
-    pub(crate) phantom: PhantomData<(E, S)>,
+    // FIXME try remove OA, OB? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OA, OB, E, S)>,
 }
 
-impl<A: Copy, B: Copy, E, S> Copy for ThenIgnore<A, B, E, S> {}
-impl<A: Clone, B: Clone, E, S> Clone for ThenIgnore<A, B, E, S> {
+impl<A: Copy, B: Copy, OA, OB, E, S> Copy for ThenIgnore<A, B, OA, OB, E, S> {}
+impl<A: Clone, B: Clone, OA, OB, E, S> Clone for ThenIgnore<A, B, OA, OB, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser_a: self.parser_a.clone(),
@@ -357,33 +355,31 @@ impl<A: Clone, B: Clone, E, S> Clone for ThenIgnore<A, B, E, S> {
     }
 }
 
-impl<'a, I, E, S, A, B> Parser<'a, I, E, S> for ThenIgnore<A, B, E, S>
+impl<'a, I, O, E, S, A, B, OA, OB> Parser<'a, I, O, E, S> for ThenIgnore<A, B, OA, OB, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    B: Parser<'a, I, E, S>,
+    A: Parser<'a, I, OA, E, S>,
+    B: Parser<'a, I, OB, E, S>,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, OA, E> {
         let a = self.parser_a.go::<M>(inp)?;
         let _b = self.parser_b.go::<Check>(inp)?;
-        Ok(M::map(a, |a: A::Output| a))
+        Ok(M::map(a, |a: OA| a))
     }
 
     go_extra!();
 }
 
-pub struct ThenWith<A, B, F, I: ?Sized, E = (), S = ()> {
+pub struct ThenWith<A, B, OA, OB, F, I: ?Sized, E = (), S = ()> {
     pub(crate) parser: A,
     pub(crate) then: F,
-    pub(crate) phantom: PhantomData<(B, E, S, I)>,
+    pub(crate) phantom: PhantomData<(B, OA, OB, E, S, I)>,
 }
 
-impl<A: Copy, B, F: Copy, I: ?Sized, E, S> Copy for ThenWith<A, B, F, I, E, S> {}
-impl<A: Clone, B, F: Clone, I: ?Sized, E, S> Clone for ThenWith<A, B, F, I, E, S> {
+impl<A: Copy, B, OA, OB, F: Copy, I: ?Sized, E, S> Copy for ThenWith<A, B, OA, OB, F, I, E, S> {}
+impl<A: Clone, B, OA, OB, F: Clone, I: ?Sized, E, S> Clone for ThenWith<A, B, OA, OB, F, I, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser: self.parser.clone(),
@@ -393,18 +389,16 @@ impl<A: Clone, B, F: Clone, I: ?Sized, E, S> Clone for ThenWith<A, B, F, I, E, S
     }
 }
 
-impl<'a, I, E, S, A, B, F> Parser<'a, I, E, S> for ThenWith<A, B, F, I, E, S>
+impl<'a, I, O, E, S, A, B, OA, OB, F> Parser<'a, I, O, E, S> for ThenWith<A, B, OA, OB, F, I, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    B: Parser<'a, I, E, S>,
-    F: Fn(A::Output) -> B,
+    A: Parser<'a, I, OA, E, S>,
+    B: Parser<'a, I, OB, E, S>,
+    F: Fn(OA) -> B,
 {
-    type Output = B::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, OB, E> {
         let before = inp.save();
         match self.parser.go::<Emit>(inp) {
             Ok(output) => {
@@ -430,76 +424,76 @@ where
 }
 
 #[derive(Copy, Clone)]
-pub struct DelimitedBy<A, B, C> {
+pub struct DelimitedBy<A, B, C, OA, OB, OC> {
     pub(crate) parser: A,
     pub(crate) start: B,
     pub(crate) end: C,
+    // FIXME try remove OA, OB, OC? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OA, OB, OC)>,
 }
 
-impl<'a, I, E, S, A, B, C> Parser<'a, I, E, S> for DelimitedBy<A, B, C>
+impl<'a, I, O, E, S, A, B, C, OA, OB, OC> Parser<'a, I, O, E, S> for DelimitedBy<A, B, C, OA, OB, OC>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    B: Parser<'a, I, E, S>,
-    C: Parser<'a, I, E, S>,
+    A: Parser<'a, I, OA, E, S>,
+    B: Parser<'a, I, OB, E, S>,
+    C: Parser<'a, I, OC, E, S>,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, OA, E> {
         let _ = self.start.go::<Check>(inp)?;
-        let b = self.parser.go::<M>(inp)?;
+        let a = self.parser.go::<M>(inp)?;
         let _ = self.end.go::<Check>(inp)?;
-        Ok(b)
+        Ok(a)
     }
 
     go_extra!();
 }
 
 #[derive(Copy, Clone)]
-pub struct PaddedBy<A, B> {
+pub struct PaddedBy<A, B, OA, OB> {
     pub(crate) parser: A,
     pub(crate) padding: B,
+    // FIXME try remove OA, OB? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OA, OB)>,
 }
 
-impl<'a, I, E, S, A, B> Parser<'a, I, E, S> for PaddedBy<A, B>
+impl<'a, I, O, E, S, A, B, OA, OB> Parser<'a, I, O, E, S> for PaddedBy<A, B, OA, OB>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    B: Parser<'a, I, E, S>,
+    A: Parser<'a, I, OA, E, S>,
+    B: Parser<'a, I, OB, E, S>,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, OA, E> {
         let _ = self.padding.go::<Check>(inp)?;
-        let b = self.parser.go::<M>(inp)?;
+        let a = self.parser.go::<M>(inp)?;
         let _ = self.padding.go::<Check>(inp)?;
-        Ok(b)
+        Ok(a)
     }
 
     go_extra!();
 }
 
 #[derive(Copy, Clone)]
-pub struct Or<A, B> {
+pub struct Or<A, B, O> {
     pub(crate) parser_a: A,
     pub(crate) parser_b: B,
+    // FIXME try remove O? See comment in Map declaration
+    pub(crate) phantom: PhantomData<O>,
 }
 
-impl<'a, I, E, S, A, B> Parser<'a, I, E, S> for Or<A, B>
+impl<'a, I, O, E, S, A, B> Parser<'a, I, O, E, S> for Or<A, B, O>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    B: Parser<'a, I, E, S, Output = A::Output>,
+    A: Parser<'a, I, O, E, S>,
+    B: Parser<'a, I, O, E, S>,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E> {
         let before = inp.save();
         match self.parser_a.go::<M>(inp) {
             Ok(out) => Ok(out),
@@ -523,17 +517,15 @@ pub struct RecoverWith<A, F> {
     pub(crate) fallback: F,
 }
 
-impl<'a, I, E, S, A, F> Parser<'a, I, E, S> for RecoverWith<A, F>
+impl<'a, I, O, E, S, A, F> Parser<'a, I, O, E, S> for RecoverWith<A, F>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    F: Parser<'a, I, E, S, Output = A::Output>,
+    A: Parser<'a, I, O, E, S>,
+    F: Parser<'a, I, O, E, S>,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E> {
         let before = inp.save();
         match self.parser.go::<M>(inp) {
             Ok(out) => Ok(out),
@@ -611,15 +603,17 @@ impl<T: Ord> Container<T> for alloc::collections::BTreeSet<T> {
     }
 }
 
-pub struct Repeated<A, I: ?Sized, C = (), E = (), S = ()> {
+// FIXME: why C, E, S have default values?
+pub struct Repeated<A, I: ?Sized, O, C = (), E = (), S = ()> {
     pub(crate) parser: A,
     pub(crate) at_least: usize,
     pub(crate) at_most: Option<usize>,
-    pub(crate) phantom: PhantomData<(C, E, S, I)>,
+    // FIXME try remove O? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(O, C, E, S, I)>,
 }
 
-impl<A: Copy, I: ?Sized, C, E, S> Copy for Repeated<A, I, C, E, S> {}
-impl<A: Clone, I: ?Sized, C, E, S> Clone for Repeated<A, I, C, E, S> {
+impl<A: Copy, I: ?Sized, O, C, E, S> Copy for Repeated<A, I, O, C, E, S> {}
+impl<A: Clone, I: ?Sized, O, C, E, S> Clone for Repeated<A, I, O, C, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser: self.parser.clone(),
@@ -630,7 +624,13 @@ impl<A: Clone, I: ?Sized, C, E, S> Clone for Repeated<A, I, C, E, S> {
     }
 }
 
-impl<'a, A: Parser<'a, I, E, S>, I: Input + ?Sized, C, E: Error<I>, S: 'a> Repeated<A, I, C, E, S> {
+impl<'a, A, I, O, C, E, S> Repeated<A, I, O, C, E, S>
+where
+    A: Parser<'a, I, O, E, S>,
+    I: Input + ?Sized,
+    E: Error<I>,
+    S: 'a,
+{
     pub fn at_least(self, at_least: usize) -> Self {
         Self { at_least, ..self }
     }
@@ -650,9 +650,9 @@ impl<'a, A: Parser<'a, I, E, S>, I: Input + ?Sized, C, E: Error<I>, S: 'a> Repea
         }
     }
 
-    pub fn collect<D: Container<A::Output>>(self) -> Repeated<A, I, D, E, S>
+    pub fn collect<D: Container<A::Output>>(self) -> Repeated<A, I, O, D, E, S>
     where
-        A: Parser<'a, I, E, S>,
+        A: Parser<'a, I, O, E, S>,
     {
         Repeated {
             parser: self.parser,
@@ -663,17 +663,15 @@ impl<'a, A: Parser<'a, I, E, S>, I: Input + ?Sized, C, E: Error<I>, S: 'a> Repea
     }
 }
 
-impl<'a, I, E, S, A, C> Parser<'a, I, E, S> for Repeated<A, I, C, E, S>
+impl<'a, I, O, E, S, A, C> Parser<'a, I, O, E, S> for Repeated<A, I, O, C, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    C: Container<A::Output>,
+    A: Parser<'a, I, O, E, S>,
+    C: Container<O>,
 {
-    type Output = C;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, C, E> {
         let mut count = 0;
         let mut output = M::bind::<C, _>(|| C::default());
         loop {
@@ -707,18 +705,19 @@ where
     go_extra!();
 }
 
-pub struct SeparatedBy<A, B, I: ?Sized, C = (), E = (), S = ()> {
+pub struct SeparatedBy<A, B, OA, OB, I: ?Sized, C = (), E = (), S = ()> {
     pub(crate) parser: A,
     pub(crate) separator: B,
     pub(crate) at_least: usize,
     pub(crate) at_most: Option<usize>,
     pub(crate) allow_leading: bool,
     pub(crate) allow_trailing: bool,
-    pub(crate) phantom: PhantomData<(C, E, S, I)>,
+    // FIXME try remove OA, OB? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OA, OB, C, E, S, I)>,
 }
 
-impl<A: Copy, B: Copy, I: ?Sized, C, E, S> Copy for SeparatedBy<A, B, I, C, E, S> {}
-impl<A: Clone, B: Clone, I: ?Sized, C, E, S> Clone for SeparatedBy<A, B, I, C, E, S> {
+impl<A: Copy, B: Copy, OA, OB, I: ?Sized, C, E, S> Copy for SeparatedBy<A, B, OA, OB, I, C, E, S> {}
+impl<A: Clone, B: Clone, OA, OB, I: ?Sized, C, E, S> Clone for SeparatedBy<A, B, OA, OB, I, C, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser: self.parser.clone(),
@@ -732,15 +731,13 @@ impl<A: Clone, B: Clone, I: ?Sized, C, E, S> Clone for SeparatedBy<A, B, I, C, E
     }
 }
 
-impl<
-        'a,
-        A: Parser<'a, I, E, S>,
-        B: Parser<'a, I, E, S>,
-        I: Input + ?Sized,
-        C,
-        E: Error<I>,
-        S: 'a,
-    > SeparatedBy<A, B, I, C, E, S>
+impl<'a, A, B, OA, OB, I, C, E, S> SeparatedBy<A, B, OA, OB, I, C, E, S>
+where
+    A: Parser<'a, I, OA, E, S>,
+    B: Parser<'a, I, OB, E, S>,
+    I: Input + ?Sized,
+    E: Error<I>,
+    S: 'a,
 {
     pub fn at_least(self, at_least: usize) -> Self {
         Self { at_least, ..self }
@@ -775,10 +772,10 @@ impl<
         }
     }
 
-    pub fn collect<D: Container<A::Output>>(self) -> SeparatedBy<A, B, I, D, E, S>
+    pub fn collect<D: Container<OA>>(self) -> SeparatedBy<A, B, OA, OB, I, D, E, S>
     where
-        A: Parser<'a, I, E, S>,
-        B: Parser<'a, I, E, S>,
+        A: Parser<'a, I, OA, E, S>,
+        B: Parser<'a, I, OB, E, S>,
     {
         SeparatedBy {
             parser: self.parser,
@@ -792,18 +789,16 @@ impl<
     }
 }
 
-impl<'a, I, E, S, A, B, C> Parser<'a, I, E, S> for SeparatedBy<A, B, I, C, E, S>
+impl<'a, I, E, S, A, B, OA, OB, C> Parser<'a, I, OA, E, S> for SeparatedBy<A, B, OA, OB, I, C, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    B: Parser<'a, I, E, S>,
-    C: Container<A::Output>,
+    A: Parser<'a, I, OA, E, S>,
+    B: Parser<'a, I, OB, E, S>,
+    C: Container<OA>,
 {
-    type Output = C;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, C, E> {
         // STEPS:
         // 1. If allow_leading -> Consume separator if there
         //    if Ok  -> continue
@@ -937,16 +932,14 @@ pub struct OrNot<A> {
     pub(crate) parser: A,
 }
 
-impl<'a, I, E, S, A> Parser<'a, I, E, S> for OrNot<A>
+impl<'a, I, O, E, S, A> Parser<'a, I, O, E, S> for OrNot<A>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
+    A: Parser<'a, I, O, E, S>,
 {
-    type Output = Option<A::Output>;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Option<O>, E> {
         let before = inp.save();
         Ok(match self.parser.go::<M>(inp) {
             Ok(o) => M::map::<A::Output, _, _>(o, Some),
@@ -965,16 +958,14 @@ pub struct Not<A> {
     pub(crate) parser: A,
 }
 
-impl<'a, I, E, S, A> Parser<'a, I, E, S> for Not<A>
+impl<'a, I, O, E, S, A> Parser<'a, I, O, E, S> for Not<A>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
+    A: Parser<'a, I, O, E, S>,
 {
-    type Output = ();
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, (), E> {
         let before = inp.save();
 
         let result = self.parser.go::<Check>(inp);
@@ -996,22 +987,22 @@ where
 }
 
 #[derive(Copy, Clone)]
-pub struct AndIs<A, B> {
+pub struct AndIs<A, B, OB> {
     pub(crate) parser_a: A,
     pub(crate) parser_b: B,
+    // FIXME try remove OB? See comment in Map declaration
+    pub(crate) phantom: PhantomData<OB>,
 }
 
-impl<'a, I, E, S, A, B> Parser<'a, I, E, S> for AndIs<A, B>
+impl<'a, I, E, S, A, B, OA, OB> Parser<'a, I, OA, E, S> for AndIs<A, B, OB>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    B: Parser<'a, I, E, S>,
+    A: Parser<'a, I, OA, E, S>,
+    B: Parser<'a, I, OB, E, S>,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, OA, E> {
         let before = inp.save();
         match self.parser_a.go::<M>(inp) {
             Ok(out) => {
@@ -1076,17 +1067,20 @@ impl<T, const N: usize> ContainerExactly<T, N> for [T; N] {
 }
 
 #[derive(Copy, Clone)]
-pub struct RepeatedExactly<A, C, const N: usize> {
+pub struct RepeatedExactly<A, OA, C, const N: usize> {
     pub(crate) parser: A,
-    pub(crate) phantom: PhantomData<C>,
+    // FIXME try remove OA? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OA, C)>,
 }
 
-impl<A, C, const N: usize> RepeatedExactly<A, C, N> {
-    pub fn collect<'a, I: Input, E: Error<I>, S: 'a, D: ContainerExactly<A::Output, N>>(
-        self,
-    ) -> RepeatedExactly<A, D, N>
+impl<A, OA, C, const N: usize> RepeatedExactly<A, OA, C, N> {
+    pub fn collect<'a, I, E, S, D>(self) -> RepeatedExactly<A, OA, D, N>
     where
-        A: Parser<'a, I, E, S>,
+        A: Parser<'a, I, OA, E, S>,
+        I: Input,
+        E: Error<I>,
+        S: 'a,
+        D: ContainerExactly<OA, N>,
     {
         RepeatedExactly {
             parser: self.parser,
@@ -1095,17 +1089,15 @@ impl<A, C, const N: usize> RepeatedExactly<A, C, N> {
     }
 }
 
-impl<'a, I, E, S, A, C, const N: usize> Parser<'a, I, E, S> for RepeatedExactly<A, C, N>
+impl<'a, I, E, S, A, OA, C, const N: usize> Parser<'a, I, C, E, S> for RepeatedExactly<A, OA, C, N>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    C: ContainerExactly<A::Output, N>,
+    A: Parser<'a, I, OA, E, S>,
+    C: ContainerExactly<OA, N>,
 {
-    type Output = C;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, C, E> {
         let mut i = 0;
         let mut output = M::bind(|| C::uninit());
         loop {
@@ -1140,15 +1132,16 @@ where
 }
 
 #[derive(Copy, Clone)]
-pub struct SeparatedByExactly<A, B, C, const N: usize> {
+pub struct SeparatedByExactly<A, B, OB, C, const N: usize> {
     pub(crate) parser: A,
     pub(crate) separator: B,
     pub(crate) allow_leading: bool,
     pub(crate) allow_trailing: bool,
-    pub(crate) phantom: PhantomData<C>,
+    // FIXME try remove OB? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OB, C)>,
 }
 
-impl<A, B, C, const N: usize> SeparatedByExactly<A, B, C, N> {
+impl<A, B, OB, C, const N: usize> SeparatedByExactly<A, B, OB, C, N> {
     pub fn allow_leading(self) -> Self {
         Self {
             allow_leading: true,
@@ -1163,11 +1156,13 @@ impl<A, B, C, const N: usize> SeparatedByExactly<A, B, C, N> {
         }
     }
 
-    pub fn collect<'a, I: Input, E: Error<I>, S: 'a, D: ContainerExactly<A::Output, N>>(
-        self,
-    ) -> SeparatedByExactly<A, B, D, N>
+    pub fn collect<'a, I, OA, E, S, D>(self) -> SeparatedByExactly<A, B, OB, D, N>
     where
-        A: Parser<'a, I, E, S>,
+        A: Parser<'a, I, OA, E, S>,
+        I: Input,
+        E: Error<I>,
+        S: 'a,
+        D: ContainerExactly<OA, N>,
     {
         SeparatedByExactly {
             parser: self.parser,
@@ -1179,18 +1174,18 @@ impl<A, B, C, const N: usize> SeparatedByExactly<A, B, C, N> {
     }
 }
 
-impl<'a, I, E, S, A, B, C, const N: usize> Parser<'a, I, E, S> for SeparatedByExactly<A, B, C, N>
+// FIXME: why parser output is not C ?
+impl<'a, I, E, S, A, B, OA, OB, C, const N: usize> Parser<'a, I, [OA; N], E, S> for SeparatedByExactly<A, B, OB, C, N>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    B: Parser<'a, I, E, S>,
-    C: ContainerExactly<A::Output, N>,
+    A: Parser<'a, I, OA, E, S>,
+    B: Parser<'a, I, OB, E, S>,
+    C: ContainerExactly<OA, N>,
 {
-    type Output = [A::Output; N];
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    // FIXME: why parse result output is not C ?
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, [OA; N], E> {
         if self.allow_leading {
             let before_separator = inp.save();
             if let Err(_) = self.separator.go::<Check>(inp) {

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -36,7 +36,7 @@ where
         Ok(M::bind(|| (self.mapper)(inp.slice(before..after))))
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 pub struct Filter<A, F> {
@@ -77,7 +77,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 #[derive(Copy, Clone)]
@@ -107,7 +107,7 @@ where
             .map(|out| M::map(out, &self.mapper))
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 #[derive(Copy, Clone)]
@@ -136,7 +136,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 #[derive(Copy, Clone)]
@@ -166,7 +166,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 #[derive(Copy, Clone)]
@@ -196,7 +196,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 #[derive(Copy, Clone)]
@@ -227,7 +227,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 pub struct To<A, OA, O, E = (), S = ()> {
@@ -262,7 +262,7 @@ where
             .map(|_| M::bind(|| self.to.clone()))
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 pub type Ignored<A, OA, E = (), S = ()> = To<A, OA, (), E, S>;
@@ -285,7 +285,7 @@ impl<A: Clone, B: Clone, OA, OB, E, S> Clone for Then<A, B, OA, OB, E, S> {
     }
 }
 
-impl<'a, I, O, E, S, A, B, OA, OB> Parser<'a, I, O, E, S> for Then<A, B, OA, OB, E, S>
+impl<'a, I, E, S, A, B, OA, OB> Parser<'a, I, (OA, OB), E, S> for Then<A, B, OA, OB, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -299,18 +299,18 @@ where
         Ok(M::combine(a, b, |a: OA, b: OB| (a, b)))
     }
 
-    go_extra!();
+    go_extra!((OA, OB));
 }
 
-pub struct IgnoreThen<A, B, OA, OB, E = (), S = ()> {
+pub struct IgnoreThen<A, B, OA, E = (), S = ()> {
     pub(crate) parser_a: A,
     pub(crate) parser_b: B,
-    // FIXME try remove OA, OB? See comment in Map declaration
-    pub(crate) phantom: PhantomData<(OA, OB, E, S)>,
+    // FIXME try remove OA? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OA, E, S)>,
 }
 
-impl<A: Copy, B: Copy, OA, OB, E, S> Copy for IgnoreThen<A, B, OA, OB, E, S> {}
-impl<A: Clone, B: Clone, OA, OB, E, S> Clone for IgnoreThen<A, B, OA, OB, E, S> {
+impl<A: Copy, B: Copy, OA, E, S> Copy for IgnoreThen<A, B, OA, E, S> {}
+impl<A: Clone, B: Clone, OA, E, S> Clone for IgnoreThen<A, B, OA, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser_a: self.parser_a.clone(),
@@ -320,7 +320,7 @@ impl<A: Clone, B: Clone, OA, OB, E, S> Clone for IgnoreThen<A, B, OA, OB, E, S> 
     }
 }
 
-impl<'a, I, O, E, S, A, B, OA, OB> Parser<'a, I, O, E, S> for IgnoreThen<A, B, OA, OB, E, S>
+impl<'a, I, E, S, A, B, OA, OB> Parser<'a, I, OB, E, S> for IgnoreThen<A, B, OA, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -334,18 +334,18 @@ where
         Ok(M::map(b, |b: OB| b))
     }
 
-    go_extra!();
+    go_extra!(OB);
 }
 
-pub struct ThenIgnore<A, B, OA, OB, E = (), S = ()> {
+pub struct ThenIgnore<A, B, OB, E = (), S = ()> {
     pub(crate) parser_a: A,
     pub(crate) parser_b: B,
-    // FIXME try remove OA, OB? See comment in Map declaration
-    pub(crate) phantom: PhantomData<(OA, OB, E, S)>,
+    // FIXME try remove OB? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OB, E, S)>,
 }
 
-impl<A: Copy, B: Copy, OA, OB, E, S> Copy for ThenIgnore<A, B, OA, OB, E, S> {}
-impl<A: Clone, B: Clone, OA, OB, E, S> Clone for ThenIgnore<A, B, OA, OB, E, S> {
+impl<A: Copy, B: Copy, OB, E, S> Copy for ThenIgnore<A, B, OB, E, S> {}
+impl<A: Clone, B: Clone, OB, E, S> Clone for ThenIgnore<A, B, OB, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser_a: self.parser_a.clone(),
@@ -355,7 +355,7 @@ impl<A: Clone, B: Clone, OA, OB, E, S> Clone for ThenIgnore<A, B, OA, OB, E, S> 
     }
 }
 
-impl<'a, I, O, E, S, A, B, OA, OB> Parser<'a, I, O, E, S> for ThenIgnore<A, B, OA, OB, E, S>
+impl<'a, I, E, S, A, B, OA, OB> Parser<'a, I, OA, E, S> for ThenIgnore<A, B, OB, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -369,17 +369,18 @@ where
         Ok(M::map(a, |a: OA| a))
     }
 
-    go_extra!();
+    go_extra!(OA);
 }
 
-pub struct ThenWith<A, B, OA, OB, F, I: ?Sized, E = (), S = ()> {
+pub struct ThenWith<A, B, OA, F, I: ?Sized, E = (), S = ()> {
     pub(crate) parser: A,
     pub(crate) then: F,
-    pub(crate) phantom: PhantomData<(B, OA, OB, E, S, I)>,
+    // FIXME try remove OA? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(B, OA, E, S, I)>,
 }
 
-impl<A: Copy, B, OA, OB, F: Copy, I: ?Sized, E, S> Copy for ThenWith<A, B, OA, OB, F, I, E, S> {}
-impl<A: Clone, B, OA, OB, F: Clone, I: ?Sized, E, S> Clone for ThenWith<A, B, OA, OB, F, I, E, S> {
+impl<A: Copy, B, OA, F: Copy, I: ?Sized, E, S> Copy for ThenWith<A, B, OA, F, I, E, S> {}
+impl<A: Clone, B, OA, F: Clone, I: ?Sized, E, S> Clone for ThenWith<A, B, OA, F, I, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser: self.parser.clone(),
@@ -389,7 +390,7 @@ impl<A: Clone, B, OA, OB, F: Clone, I: ?Sized, E, S> Clone for ThenWith<A, B, OA
     }
 }
 
-impl<'a, I, O, E, S, A, B, OA, OB, F> Parser<'a, I, O, E, S> for ThenWith<A, B, OA, OB, F, I, E, S>
+impl<'a, I, E, S, A, B, OA, OB, F> Parser<'a, I, OB, E, S> for ThenWith<A, B, OA, F, I, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -420,19 +421,19 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(OB);
 }
 
 #[derive(Copy, Clone)]
-pub struct DelimitedBy<A, B, C, OA, OB, OC> {
+pub struct DelimitedBy<A, B, C, OB, OC> {
     pub(crate) parser: A,
     pub(crate) start: B,
     pub(crate) end: C,
-    // FIXME try remove OA, OB, OC? See comment in Map declaration
-    pub(crate) phantom: PhantomData<(OA, OB, OC)>,
+    // FIXME try remove OB, OC? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OB, OC)>,
 }
 
-impl<'a, I, O, E, S, A, B, C, OA, OB, OC> Parser<'a, I, O, E, S> for DelimitedBy<A, B, C, OA, OB, OC>
+impl<'a, I, E, S, A, B, C, OA, OB, OC> Parser<'a, I, OA, E, S> for DelimitedBy<A, B, C, OB, OC>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -448,18 +449,18 @@ where
         Ok(a)
     }
 
-    go_extra!();
+    go_extra!(OA);
 }
 
 #[derive(Copy, Clone)]
-pub struct PaddedBy<A, B, OA, OB> {
+pub struct PaddedBy<A, B, OB> {
     pub(crate) parser: A,
     pub(crate) padding: B,
-    // FIXME try remove OA, OB? See comment in Map declaration
-    pub(crate) phantom: PhantomData<(OA, OB)>,
+    // FIXME try remove OB? See comment in Map declaration
+    pub(crate) phantom: PhantomData<OB>,
 }
 
-impl<'a, I, O, E, S, A, B, OA, OB> Parser<'a, I, O, E, S> for PaddedBy<A, B, OA, OB>
+impl<'a, I, E, S, A, B, OA, OB> Parser<'a, I, OA, E, S> for PaddedBy<A, B, OB>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -474,7 +475,7 @@ where
         Ok(a)
     }
 
-    go_extra!();
+    go_extra!(OA);
 }
 
 #[derive(Copy, Clone)]
@@ -508,7 +509,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 #[derive(Copy, Clone)]
@@ -542,7 +543,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 pub trait Container<T>: Default {
@@ -604,16 +605,16 @@ impl<T: Ord> Container<T> for alloc::collections::BTreeSet<T> {
 }
 
 // FIXME: why C, E, S have default values?
-pub struct Repeated<A, I: ?Sized, O, C = (), E = (), S = ()> {
+pub struct Repeated<A, OA, I: ?Sized, C = (), E = (), S = ()> {
     pub(crate) parser: A,
     pub(crate) at_least: usize,
     pub(crate) at_most: Option<usize>,
-    // FIXME try remove O? See comment in Map declaration
-    pub(crate) phantom: PhantomData<(O, C, E, S, I)>,
+    // FIXME try remove OA? See comment in Map declaration
+    pub(crate) phantom: PhantomData<(OA, C, E, S, I)>,
 }
 
-impl<A: Copy, I: ?Sized, O, C, E, S> Copy for Repeated<A, I, O, C, E, S> {}
-impl<A: Clone, I: ?Sized, O, C, E, S> Clone for Repeated<A, I, O, C, E, S> {
+impl<A: Copy, OA, I: ?Sized, C, E, S> Copy for Repeated<A, OA, I, C, E, S> {}
+impl<A: Clone, OA, I: ?Sized, C, E, S> Clone for Repeated<A, OA, I, C, E, S> {
     fn clone(&self) -> Self {
         Self {
             parser: self.parser.clone(),
@@ -624,9 +625,9 @@ impl<A: Clone, I: ?Sized, O, C, E, S> Clone for Repeated<A, I, O, C, E, S> {
     }
 }
 
-impl<'a, A, I, O, C, E, S> Repeated<A, I, O, C, E, S>
+impl<'a, A, OA, I, C, E, S> Repeated<A, OA, I, C, E, S>
 where
-    A: Parser<'a, I, O, E, S>,
+    A: Parser<'a, I, OA, E, S>,
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
@@ -650,9 +651,9 @@ where
         }
     }
 
-    pub fn collect<D: Container<A::Output>>(self) -> Repeated<A, I, O, D, E, S>
+    pub fn collect<D: Container<OA>>(self) -> Repeated<A, OA, I, D, E, S>
     where
-        A: Parser<'a, I, O, E, S>,
+        A: Parser<'a, I, OA, E, S>,
     {
         Repeated {
             parser: self.parser,
@@ -663,13 +664,13 @@ where
     }
 }
 
-impl<'a, I, O, E, S, A, C> Parser<'a, I, O, E, S> for Repeated<A, I, O, C, E, S>
+impl<'a, I, E, S, A, OA, C> Parser<'a, I, C, E, S> for Repeated<A, OA, I, C, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, O, E, S>,
-    C: Container<O>,
+    A: Parser<'a, I, OA, E, S>,
+    C: Container<OA>,
 {
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, C, E> {
         let mut count = 0;
@@ -702,7 +703,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(C);
 }
 
 pub struct SeparatedBy<A, B, OA, OB, I: ?Sized, C = (), E = (), S = ()> {
@@ -789,7 +790,7 @@ where
     }
 }
 
-impl<'a, I, E, S, A, B, OA, OB, C> Parser<'a, I, OA, E, S> for SeparatedBy<A, B, OA, OB, I, C, E, S>
+impl<'a, I, E, S, A, B, OA, OB, C> Parser<'a, I, C, E, S> for SeparatedBy<A, B, OA, OB, I, C, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -924,7 +925,7 @@ where
         Ok(output)
     }
 
-    go_extra!();
+    go_extra!(C);
 }
 
 #[derive(Copy, Clone)]
@@ -932,7 +933,7 @@ pub struct OrNot<A> {
     pub(crate) parser: A,
 }
 
-impl<'a, I, O, E, S, A> Parser<'a, I, O, E, S> for OrNot<A>
+impl<'a, I, O, E, S, A> Parser<'a, I, Option<O>, E, S> for OrNot<A>
 where
     I: Input + ?Sized,
     E: Error<I>,
@@ -942,28 +943,30 @@ where
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Option<O>, E> {
         let before = inp.save();
         Ok(match self.parser.go::<M>(inp) {
-            Ok(o) => M::map::<A::Output, _, _>(o, Some),
+            Ok(o) => M::map::<O, _, _>(o, Some),
             Err(_) => {
                 inp.rewind(before);
-                M::bind::<Option<A::Output>, _>(|| None)
+                M::bind::<Option<O>, _>(|| None)
             }
         })
     }
 
-    go_extra!();
+    go_extra!(Option<O>);
 }
 
 #[derive(Copy, Clone)]
-pub struct Not<A> {
+pub struct Not<A, OA> {
     pub(crate) parser: A,
+    // FIXME try remove OA? See comment in Map declaration
+    pub(crate) phantom: PhantomData<OA>,
 }
 
-impl<'a, I, O, E, S, A> Parser<'a, I, O, E, S> for Not<A>
+impl<'a, I, E, S, A, OA> Parser<'a, I, (), E, S> for Not<A, OA>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, O, E, S>,
+    A: Parser<'a, I, OA, E, S>,
 {
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, (), E> {
         let before = inp.save();
@@ -983,7 +986,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(());
 }
 
 #[derive(Copy, Clone)]
@@ -1031,7 +1034,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(OA);
 }
 
 pub trait ContainerExactly<T, const N: usize> {
@@ -1128,7 +1131,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(C);
 }
 
 #[derive(Copy, Clone)]
@@ -1237,7 +1240,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!([OA; N]);
 }
 
 pub struct Foldr<P, F, A, B, E = (), S = ()> {
@@ -1278,7 +1281,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(B);
 }
 
 pub struct Foldl<P, F, A, B, E = (), S = ()> {
@@ -1307,9 +1310,7 @@ where
     B: IntoIterator,
     F: Fn(A, B::Item) -> A,
 {
-    type Output = A;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E>
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, A, E>
     where
         Self: Sized,
     {
@@ -1320,7 +1321,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(A);
 }
 
 #[derive(Copy, Clone)]
@@ -1346,7 +1347,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 #[derive(Copy, Clone)]
@@ -1373,7 +1374,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 #[derive(Copy, Clone)]
@@ -1402,7 +1403,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 #[derive(Copy, Clone)]
@@ -1431,7 +1432,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 // TODO: Finish implementing this once full error recovery is implemented
@@ -1441,17 +1442,15 @@ pub struct Validate<A, F> {
     pub(crate) validator: F,
 }
 
-impl<'a, I, E, S, A, F> Parser<'a, I, E, S> for Validate<A, F>
+impl<'a, I, O, E, S, A, F> Parser<'a, I, O, E, S> for Validate<A, F>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
+    A: Parser<'a, I, O, E, S>,
     F: Fn(E, I::Span, &mut dyn FnMut(E)) -> E,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E>
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E>
     where
         Self: Sized,
     {
@@ -1465,7 +1464,7 @@ where
         })
     }
 
-    go_extra!();
+    go_extra!(O);
 }*/
 
 #[derive(Copy, Clone)]
@@ -1498,7 +1497,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 #[cfg(test)]

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -19,18 +19,16 @@ impl<A: Clone, F: Clone, E, S> Clone for MapSlice<A, F, E, S> {
     }
 }
 
-impl<'a, I, E, S, A, F, O> Parser<'a, I, E, S> for MapSlice<A, F, E, S>
+impl<'a, I, O, E, S, A, F> Parser<'a, I, O, E, S> for MapSlice<A, F, E, S>
 where
     I: Input + SliceInput + ?Sized,
     E: Error<I>,
     S: 'a,
     I::Slice: 'a,
-    A: Parser<'a, I, E, S>,
+    A: Parser<'a, I, O, E, S>,
     F: Fn(&'a I::Slice) -> O,
 {
-    type Output = O;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E> {
         let before = inp.save();
         self.parser.go::<Check>(inp)?;
         let after = inp.save();
@@ -56,17 +54,15 @@ impl<A: Clone, F: Clone> Clone for Filter<A, F> {
     }
 }
 
-impl<'a, A, I, E, S, F> Parser<'a, I, E, S> for Filter<A, F>
+impl<'a, A, I, O, E, S, F> Parser<'a, I, O, E, S> for Filter<A, F>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    F: Fn(&A::Output) -> bool,
+    A: Parser<'a, I, O, E, S>,
+    F: Fn(&O) -> bool,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E> {
         let before = inp.save();
         self.parser.go::<Emit>(inp).and_then(|out| {
             if (self.filter)(&out) {

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -1257,19 +1257,17 @@ impl<P: Clone, F: Clone, A, B, E, S> Clone for Foldr<P, F, A, B, E, S> {
     }
 }
 
-impl<'a, I, P, F, A, B, E, S> Parser<'a, I, E, S> for Foldr<P, F, A, B, E, S>
+impl<'a, I, P, F, A, B, E, S> Parser<'a, I, B, E, S> for Foldr<P, F, A, B, E, S>
 where
     I: Input + ?Sized,
-    P: Parser<'a, I, E, S, Output = (A, B)>,
+    P: Parser<'a, I, (A, B), E, S>,
     E: Error<I>,
     S: 'a,
     A: IntoIterator,
     A::IntoIter: DoubleEndedIterator,
     F: Fn(A::Item, B) -> B,
 {
-    type Output = B;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E>
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, B, E>
     where
         Self: Sized,
     {
@@ -1300,10 +1298,10 @@ impl<P: Clone, F: Clone, A, B, E, S> Clone for Foldl<P, F, A, B, E, S> {
     }
 }
 
-impl<'a, I, P, F, A, B, E, S> Parser<'a, I, E, S> for Foldl<P, F, A, B, E, S>
+impl<'a, I, P, F, A, B, E, S> Parser<'a, I, A, E, S> for Foldl<P, F, A, B, E, S>
 where
     I: Input + ?Sized,
-    P: Parser<'a, I, E, S, Output = (A, B)>,
+    P: Parser<'a, I, (A, B), E, S>,
     E: Error<I>,
     S: 'a,
     B: IntoIterator,
@@ -1330,16 +1328,14 @@ pub struct Rewind<A> {
     pub(crate) parser: A,
 }
 
-impl<'a, I, E, S, A> Parser<'a, I, E, S> for Rewind<A>
+impl<'a, I, O, E, S, A> Parser<'a, I, O, E, S> for Rewind<A>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
+    A: Parser<'a, I, O, E, S>,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E> {
         let before = inp.save();
         match self.parser.go::<M>(inp) {
             Ok(o) => {
@@ -1359,17 +1355,15 @@ pub struct MapErr<A, F> {
     pub(crate) mapper: F,
 }
 
-impl<'a, I, E, S, A, F> Parser<'a, I, E, S> for MapErr<A, F>
+impl<'a, I, O, E, S, A, F> Parser<'a, I, O, E, S> for MapErr<A, F>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
+    A: Parser<'a, I, O, E, S>,
     F: Fn(E) -> E,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E>
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E>
     where
         Self: Sized,
     {
@@ -1388,17 +1382,15 @@ pub struct MapErrWithSpan<A, F> {
     pub(crate) mapper: F,
 }
 
-impl<'a, I, E, S, A, F> Parser<'a, I, E, S> for MapErrWithSpan<A, F>
+impl<'a, I, O, E, S, A, F> Parser<'a, I, O, E, S> for MapErrWithSpan<A, F>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
+    A: Parser<'a, I, O, E, S>,
     F: Fn(E, I::Span) -> E,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E>
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E>
     where
         Self: Sized,
     {
@@ -1419,17 +1411,15 @@ pub struct MapErrWithState<A, F> {
     pub(crate) mapper: F,
 }
 
-impl<'a, I, E, S, A, F> Parser<'a, I, E, S> for MapErrWithState<A, F>
+impl<'a, I, O, E, S, A, F> Parser<'a, I, O, E, S> for MapErrWithState<A, F>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
+    A: Parser<'a, I, O, E, S>,
     F: Fn(E, I::Span, &mut S) -> E,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E>
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E>
     where
         Self: Sized,
     {
@@ -1484,17 +1474,15 @@ pub struct OrElse<A, F> {
     pub(crate) or_else: F,
 }
 
-impl<'a, I, E, S, A, F> Parser<'a, I, E, S> for OrElse<A, F>
+impl<'a, I, O, E, S, A, F> Parser<'a, I, O, E, S> for OrElse<A, F>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
-    A: Parser<'a, I, E, S>,
-    F: Fn(E) -> Result<A::Output, E>,
+    A: Parser<'a, I, O, E, S>,
+    F: Fn(E) -> Result<O, E>,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E>
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E>
     where
         Self: Sized,
     {

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -307,7 +307,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn to<U: Clone>(self, to: U) -> To<Self, U, E, S>
+    fn to<U: Clone>(self, to: U) -> To<Self, O, U, E, S>
     where
         Self: Sized,
     {
@@ -318,7 +318,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn then<U, B: Parser<'a, I, U, E, S>>(self, other: B) -> Then<Self, B, E, S>
+    fn then<U, B: Parser<'a, I, U, E, S>>(self, other: B) -> Then<Self, B, O, U, E, S>
     where
         Self: Sized,
     {
@@ -329,7 +329,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn ignore_then<U, B: Parser<'a, I, U, E, S>>(self, other: B) -> IgnoreThen<Self, B, E, S>
+    fn ignore_then<U, B: Parser<'a, I, U, E, S>>(self, other: B) -> IgnoreThen<Self, B, O, U, E, S>
     where
         Self: Sized,
     {
@@ -340,7 +340,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn then_ignore<U, B: Parser<'a, I, U, E, S>>(self, other: B) -> ThenIgnore<Self, B, E, S>
+    fn then_ignore<U, B: Parser<'a, I, U, E, S>>(self, other: B) -> ThenIgnore<Self, B, O, U, E, S>
     where
         Self: Sized,
     {
@@ -354,7 +354,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
     fn then_with<U, B: Parser<'a, I, U, E, S>, F: Fn(O) -> B>(
         self,
         then: F,
-    ) -> ThenWith<Self, B, F, I, E, S>
+    ) -> ThenWith<Self, B, O, U, F, I, E, S>
     where
         Self: Sized,
     {
@@ -391,7 +391,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
     ///     Some("abcd]=]efgh]===]ijkl"),
     /// );
     /// ```
-    fn and_is<U, B>(self, other: B) -> AndIs<Self, B>
+    fn and_is<U, B>(self, other: B) -> AndIs<Self, B, U>
     where
         Self: Sized,
         B: Parser<'a, I, U, E, S>,
@@ -406,7 +406,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         self,
         start: B,
         end: C,
-    ) -> DelimitedBy<Self, B, C>
+    ) -> DelimitedBy<Self, B, C, O, U, V>
     where
         Self: Sized,
         B: Parser<'a, I, U, E, S>,
@@ -419,7 +419,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn padded_by<U, B>(self, padding: B) -> PaddedBy<Self, B>
+    fn padded_by<U, B>(self, padding: B) -> PaddedBy<Self, B, O, U>
     where
         Self: Sized,
         B: Parser<'a, I, U, E, S>,
@@ -430,9 +430,10 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn or<B>(self, other: B) -> Or<Self, B>
+    fn or<B>(self, other: B) -> Or<Self, B, O>
     where
-        Self: Sized, B: Parser<'a, I, O, E, S, Output = O>
+        Self: Sized,
+        B: Parser<'a, I, O, E, S>,
     {
         Or {
             parser_a: self,
@@ -499,7 +500,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         Not { parser: self }
     }
 
-    fn repeated(self) -> Repeated<Self, I, (), E, S>
+    fn repeated(self) -> Repeated<Self, I, O, (), E, S>
     where
         Self: Sized,
     {
@@ -511,7 +512,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn repeated_exactly<const N: usize>(self) -> RepeatedExactly<Self, (), N>
+    fn repeated_exactly<const N: usize>(self) -> RepeatedExactly<Self, O, (), N>
     where
         Self: Sized,
     {
@@ -521,7 +522,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn separated_by<U, B>(self, separator: B) -> SeparatedBy<Self, B, I, (), E, S>
+    fn separated_by<U, B>(self, separator: B) -> SeparatedBy<Self, B, O, U, I, (), E, S>
     where
         Self: Sized,
         B: Parser<'a, I, U, E, S>,
@@ -540,7 +541,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
     fn separated_by_exactly<U, B, const N: usize>(
         self,
         separator: B,
-    ) -> SeparatedByExactly<Self, B, (), N>
+    ) -> SeparatedByExactly<Self, B, U, (), N>
     where
         Self: Sized,
         B: Parser<'a, I, U, E, S>,

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -773,7 +773,7 @@ fn zero_copy() {
     //     Branch(Box<Self>),
     // }
 
-    // fn parser2() -> impl Parser<'static, str, Output = TokenTest> {
+    // fn parser2() -> impl Parser<'static, str, TokenTest> {
     //     recursive(|token| {
     //         token
     //             .delimited_by(just('c'), just('c'))
@@ -793,7 +793,7 @@ fn zero_copy() {
 
     type Span = (FileId, Range<usize>);
 
-    fn parser<'a>() -> impl Parser<'a, WithContext<'a, FileId, str>, Output = [(Span, Token<'a>); 6]>
+    fn parser<'a>() -> impl Parser<'a, WithContext<'a, FileId, str>, [(Span, Token<'a>); 6]>
     {
         let ident = any()
             .filter(|c: &char| c.is_alphanumeric())
@@ -834,7 +834,7 @@ fn zero_copy() {
 fn zero_copy_repetition() {
     use self::prelude::*;
 
-    fn parser<'a>() -> impl Parser<'a, str, Output = Vec<u64>> {
+    fn parser<'a>() -> impl Parser<'a, str, Vec<u64>> {
         any()
             .filter(|c: &char| c.is_ascii_digit())
             .repeated()
@@ -870,7 +870,7 @@ fn zero_copy_repetition() {
 fn zero_copy_group() {
     use self::prelude::*;
 
-    fn parser<'a>() -> impl Parser<'a, str, Output = (&'a str, u64, char)> {
+    fn parser<'a>() -> impl Parser<'a, str, (&'a str, u64, char)> {
         group((
             any()
                 .filter(|c: &char| c.is_ascii_alphabetic())
@@ -912,7 +912,7 @@ fn regex_parser() {
     use self::prelude::*;
     use self::regex::*;
 
-    fn parser<'a, C: Char>() -> impl Parser<'a, C::Slice, Output = Vec<&'a C::Slice>> {
+    fn parser<'a, C: Char>() -> impl Parser<'a, C::Slice, Vec<&'a C::Slice>> {
         regex("[a-zA-Z_][a-zA-Z0-9_]*")
             .padded()
             .repeated()

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -211,7 +211,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
     #[doc(hidden)]
     fn go_check(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<Check, O, E>;
 
-    fn map_slice<O, F: Fn(&'a I::Slice) -> O>(self, f: F) -> MapSlice<Self, F, E, S>
+    fn map_slice<U, F: Fn(&'a I::Slice) -> U>(self, f: F) -> MapSlice<Self, F, E, S>
     where
         Self: Sized,
         I: SliceInput,
@@ -234,7 +234,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn map<O, F: Fn(O) -> O>(self, f: F) -> Map<Self, F>
+    fn map<U, F: Fn(O) -> U>(self, f: F) -> Map<Self, F>
     where
         Self: Sized,
     {
@@ -244,7 +244,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn map_with_span<O, F: Fn(O, I::Span) -> O>(self, f: F) -> MapWithSpan<Self, F>
+    fn map_with_span<U, F: Fn(O, I::Span) -> U>(self, f: F) -> MapWithSpan<Self, F>
     where
         Self: Sized,
     {
@@ -254,7 +254,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn map_with_state<O, F: Fn(O, I::Span, &mut S) -> O>(
+    fn map_with_state<U, F: Fn(O, I::Span, &mut S) -> U>(
         self,
         f: F,
     ) -> MapWithState<Self, F>
@@ -268,7 +268,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
     }
 
     #[doc(alias = "filter_map")]
-    fn try_map<O, F: Fn(O, I::Span) -> Result<O, E>>(self, f: F) -> TryMap<Self, F>
+    fn try_map<U, F: Fn(O, I::Span) -> Result<U, E>>(self, f: F) -> TryMap<Self, F>
     where
         Self: Sized,
     {
@@ -278,7 +278,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn try_map_with_state<O, F: Fn(O, I::Span, &mut S) -> Result<O, E>>(
+    fn try_map_with_state<U, F: Fn(O, I::Span, &mut S) -> Result<U, E>>(
         self,
         f: F,
     ) -> TryMapWithState<Self, F>
@@ -302,7 +302,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn to<O: Clone>(self, to: O) -> To<Self, O, E, S>
+    fn to<U: Clone>(self, to: U) -> To<Self, U, E, S>
     where
         Self: Sized,
     {
@@ -313,7 +313,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn then<B: Parser<'a, I, E, S>>(self, other: B) -> Then<Self, B, E, S>
+    fn then<U, B: Parser<'a, I, U, E, S>>(self, other: B) -> Then<Self, B, E, S>
     where
         Self: Sized,
     {

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -234,60 +234,65 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn map<U, F: Fn(O) -> U>(self, f: F) -> Map<Self, F>
+    fn map<U, F: Fn(O) -> U>(self, f: F) -> Map<Self, O, F>
     where
         Self: Sized,
     {
         Map {
             parser: self,
             mapper: f,
+            phantom: PhantomData,
         }
     }
 
-    fn map_with_span<U, F: Fn(O, I::Span) -> U>(self, f: F) -> MapWithSpan<Self, F>
+    fn map_with_span<U, F: Fn(O, I::Span) -> U>(self, f: F) -> MapWithSpan<Self, O, F>
     where
         Self: Sized,
     {
         MapWithSpan {
             parser: self,
             mapper: f,
+            phantom: PhantomData,
         }
     }
 
     fn map_with_state<U, F: Fn(O, I::Span, &mut S) -> U>(
         self,
         f: F,
-    ) -> MapWithState<Self, F>
+    ) -> MapWithState<Self, O, F>
     where
         Self: Sized,
     {
         MapWithState {
             parser: self,
             mapper: f,
+            phantom: PhantomData,
         }
     }
 
     #[doc(alias = "filter_map")]
-    fn try_map<U, F: Fn(O, I::Span) -> Result<U, E>>(self, f: F) -> TryMap<Self, F>
+    fn try_map<U, F: Fn(O, I::Span) -> Result<U, E>>(self, f: F) -> TryMap<Self, O, F>
     where
         Self: Sized,
     {
         TryMap {
             parser: self,
             mapper: f,
+            phantom: PhantomData,
         }
     }
 
     fn try_map_with_state<U, F: Fn(O, I::Span, &mut S) -> Result<U, E>>(
         self,
         f: F,
-    ) -> TryMapWithState<Self, F>
+    ) -> TryMapWithState<Self, O, F>
     where
         Self: Sized,
     {
         TryMapWithState {
             parser: self,
             mapper: f,
+            phantom: PhantomData,
         }
     }
 
@@ -592,7 +597,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         Padded { parser: self }
     }
 
-    fn flatten<T, Inner>(self) -> Map<Self, fn(O) -> Vec<T>>
+    fn flatten<T, Inner>(self) -> Map<Self, O, fn(O) -> Vec<T>>
     where
         Self: Sized,
         O: IntoIterator<Item = Inner>,
@@ -659,7 +664,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
       }
       }*/
 
-    fn collect<C>(self) -> Map<Self, fn(O) -> C>
+    fn collect<C>(self) -> Map<Self, O, fn(O) -> C>
     where
         Self: Sized,
         O: IntoIterator,
@@ -668,7 +673,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         self.map(|items| C::from_iter(items.into_iter()))
     }
 
-    fn chain<T, U, P>(self, other: P) -> Map<Then<Self, P, E, S>, fn((O, U)) -> Vec<T>>
+    fn chain<T, U, P>(self, other: P) -> Map<Then<Self, P, E, S>, (O, U), fn((O, U)) -> Vec<T>>
     where
         Self: Sized,
         O: Chain<T>,
@@ -694,7 +699,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
             }
         }
 
-    fn from_str<U>(self) -> Map<Self, fn(O) -> Result<U, U::Err>>
+    fn from_str<U>(self) -> Map<Self, O, fn(O) -> Result<U, U::Err>>
     where
         Self: Sized,
         U: FromStr,
@@ -703,7 +708,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         self.map(|o| o.as_ref().parse())
     }
 
-    fn unwrapped<U, E1>(self) -> Map<Self, fn(Result<U, E1>) -> U>
+    fn unwrapped<U, E1>(self) -> Map<Self, O, fn(Result<U, E1>) -> U>
     where
         Self: Sized + Parser<'a, I, Result<U, E1>, E, S>,
         E1: fmt::Debug,

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -440,7 +440,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         }
     }
 
-    fn or<B>(self, other: B) -> Or<Self, B, O>
+    fn or<B>(self, other: B) -> Or<Self, B>
     where
         Self: Sized,
         B: Parser<'a, I, O, E, S>,
@@ -448,7 +448,6 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
         Or {
             parser_a: self,
             parser_b: other,
-            phantom: PhantomData,
         }
     }
 

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -536,20 +536,20 @@ macro_rules! flatten_map {
 
 macro_rules! impl_group_for_tuple {
     () => {};
-    ($head:ident $($X:ident)*) => {
-        impl_group_for_tuple!($($X)*);
-        impl_group_for_tuple!(~ $head $($X)*);
+    ($head:ident $ohead:ident $($X:ident $O:ident)*) => {
+        impl_group_for_tuple!($($X $O)*);
+        impl_group_for_tuple!(~ $head $ohead $($X $O)*);
     };
-    (~ $($X:ident)*) => {
+    (~ $($X:ident $O:ident)*) => {
         #[allow(unused_variables, non_snake_case)]
-        impl<'a, I, E, S, $($X,)* $(O$X),*> Parser<'a, I, ($(O$X),*), E, S> for Group<($($X,)*)>
+        impl<'a, I, E, S, $($X),*, $($O),*> Parser<'a, I, ($($O,)*), E, S> for Group<($($X,)*)>
         where
             I: Input + ?Sized,
             E: Error<I>,
             S: 'a,
-            $($X: Parser<'a, I, O$X, E, S>),*
+            $($X: Parser<'a, I, $O, E, S>),*
         {
-            fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, ($(O$X),*), E> {
+            fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, ($($O,)*), E> {
                 let Group { parsers: ($($X,)*) } = self;
 
                 $(
@@ -559,10 +559,36 @@ macro_rules! impl_group_for_tuple {
                 Ok(flatten_map!(<M> $($X)*))
             }
 
-            go_extra!(($(O$X),*));
+            go_extra!(($($O,)*));
         }
     };
 }
 
-// FIXME: uncomment and fix trait bounds!! I(bew) don't know how to write advanced macros like this
-//impl_group_for_tuple!(A_ B_ C_ D_ E_ F_ G_ H_ I_ J_ K_ L_ M_ N_ O_ P_ Q_ S_ T_ U_ V_ W_ X_ Y_ Z_);
+impl_group_for_tuple! {
+    A_ OA
+    B_ OB
+    C_ OC
+    D_ OD
+    E_ OE
+    F_ OF
+    G_ OG
+    H_ OH
+    I_ OI
+    J_ OJ
+    K_ OK
+    L_ OL
+    M_ OM
+    N_ ON
+    O_ OO
+    P_ OP
+    Q_ OQ
+    R_ OR
+    S_ OS
+    T_ OT
+    U_ OU
+    V_ OV
+    W_ OW
+    X_ OX
+    Y_ OY
+    Z_ OZ
+}

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -337,7 +337,7 @@ where
     S: 'a,
     P: Parser<'a, I, OP, E, S>,
 {
-    pub fn collect<D: Container<P::Output>>(self) -> TakeUntil<P, OP, D> {
+    pub fn collect<D: Container<OP>>(self) -> TakeUntil<P, OP, D> {
         TakeUntil {
             until: self.until,
             phantom: PhantomData,

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -30,7 +30,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(());
 }
 
 pub struct Empty<I: ?Sized>(PhantomData<I>);
@@ -56,7 +56,7 @@ where
         Ok(M::bind(|| ()))
     }
 
-    go_extra!();
+    go_extra!(());
 }
 
 pub trait Seq<T> {
@@ -182,7 +182,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(T);
 }
 
 pub struct OneOf<T, I: ?Sized, E = (), S = ()> {
@@ -232,7 +232,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(I::Token);
 }
 
 pub struct NoneOf<T, I: ?Sized, E = (), S = ()> {
@@ -282,7 +282,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(I::Token);
 }
 
 pub struct Any<I: ?Sized, E, S = ()> {
@@ -315,7 +315,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!(I::Token);
 }
 
 pub const fn any<I: Input + ?Sized, E: Error<I>, S>() -> Any<I, E, S> {
@@ -400,7 +400,7 @@ where
         }
     }
 
-    go_extra!();
+    go_extra!((C, OP));
 }
 
 pub struct Todo<I: ?Sized, E>(PhantomData<(E, I)>);
@@ -426,7 +426,7 @@ where
         todo!("Attempted to use an unimplemented parser")
     }
 
-    go_extra!();
+    go_extra!(());
 }
 
 pub struct Choice<T, O> {
@@ -489,7 +489,7 @@ macro_rules! impl_choice_for_tuple {
                 Err(err.unwrap_or_else(|| Located::at(inp.last_pos(), E::expected_found(None, None, inp.span_since(before)))))
             }
 
-            go_extra!();
+            go_extra!(O);
         }
     };
 }
@@ -559,7 +559,7 @@ macro_rules! impl_group_for_tuple {
                 Ok(flatten_map!(<M> $($X)*))
             }
 
-            go_extra!();
+            go_extra!(($(O$X),*));
         }
     };
 }

--- a/src/zero_copy/recursive.rs
+++ b/src/zero_copy/recursive.rs
@@ -73,7 +73,7 @@ where
         )
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 impl<'a, I, O, E, S> Parser<'a, I, O, E, S> for Recursive<Direct<'a, I, O, E, S>>
@@ -86,7 +86,7 @@ where
         M::invoke(&*self.parser(), inp)
     }
 
-    go_extra!();
+    go_extra!(O);
 }
 
 pub fn recursive<'a, I, O, E, S, A, F>(f: F) -> Recursive<Direct<'a, I, O, E, S>>

--- a/src/zero_copy/recursive.rs
+++ b/src/zero_copy/recursive.rs
@@ -5,12 +5,12 @@ enum RecursiveInner<T: ?Sized> {
     Unowned(Weak<T>),
 }
 
-type OnceParser<'a, I, O, E, S> = OnceCell<Box<dyn Parser<'a, I, O, E, S, Output = O> + 'a>>;
+type OnceParser<'a, I, O, E, S> = OnceCell<Box<dyn Parser<'a, I, O, E, S> + 'a>>;
 
-pub type Direct<'a, I, O, E, S = ()> = dyn Parser<'a, I, O, E, S, Output = O> + 'a;
+pub type Direct<'a, I, O, E, S = ()> = dyn Parser<'a, I, O, E, S> + 'a;
 
 pub struct Indirect<'a, I: ?Sized, O, E, S = ()> {
-    inner: OnceCell<Box<dyn Parser<'a, I, O, E, S, Output = O> + 'a>>,
+    inner: OnceCell<Box<dyn Parser<'a, I, O, E, S> + 'a>>,
 }
 
 pub struct Recursive<P: ?Sized> {

--- a/src/zero_copy/recursive.rs
+++ b/src/zero_copy/recursive.rs
@@ -5,12 +5,12 @@ enum RecursiveInner<T: ?Sized> {
     Unowned(Weak<T>),
 }
 
-type OnceParser<'a, I, O, E, S> = OnceCell<Box<dyn Parser<'a, I, E, S, Output = O> + 'a>>;
+type OnceParser<'a, I, O, E, S> = OnceCell<Box<dyn Parser<'a, I, O, E, S, Output = O> + 'a>>;
 
-pub type Direct<'a, I, O, E, S = ()> = dyn Parser<'a, I, E, S, Output = O> + 'a;
+pub type Direct<'a, I, O, E, S = ()> = dyn Parser<'a, I, O, E, S, Output = O> + 'a;
 
 pub struct Indirect<'a, I: ?Sized, O, E, S = ()> {
-    inner: OnceCell<Box<dyn Parser<'a, I, E, S, Output = O> + 'a>>,
+    inner: OnceCell<Box<dyn Parser<'a, I, O, E, S, Output = O> + 'a>>,
 }
 
 pub struct Recursive<P: ?Sized> {
@@ -26,7 +26,7 @@ impl<'a, I: Input + ?Sized, O, E: Error<I>, S> Recursive<Indirect<'a, I, O, E, S
         }
     }
 
-    pub fn define<P: Parser<'a, I, E, S, Output = O> + 'a>(&mut self, parser: P) {
+    pub fn define<P: Parser<'a, I, O, E, S> + 'a>(&mut self, parser: P) {
         self.parser()
             .inner
             .set(Box::new(parser))
@@ -56,15 +56,13 @@ impl<P: ?Sized> Clone for Recursive<P> {
     }
 }
 
-impl<'a, I, E, S, O> Parser<'a, I, E, S> for Recursive<Indirect<'a, I, O, E, S>>
+impl<'a, I, O, E, S> Parser<'a, I, O, E, S> for Recursive<Indirect<'a, I, O, E, S>>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
 {
-    type Output = O;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E> {
         M::invoke(
             self.parser()
                 .inner
@@ -78,33 +76,29 @@ where
     go_extra!();
 }
 
-impl<'a, I, E, S, O> Parser<'a, I, E, S> for Recursive<Direct<'a, I, O, E, S>>
+impl<'a, I, O, E, S> Parser<'a, I, O, E, S> for Recursive<Direct<'a, I, O, E, S>>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
 {
-    type Output = O;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E> {
         M::invoke(&*self.parser(), inp)
     }
 
     go_extra!();
 }
 
-pub fn recursive<
-    'a,
+pub fn recursive<'a, I, O, E, S, A, F>(f: F) -> Recursive<Direct<'a, I, O, E, S>>
+where
     I: Input + ?Sized,
     E: Error<I>,
-    S,
-    A: Parser<'a, I, E, S> + 'a,
-    F: FnOnce(Recursive<Direct<'a, I, A::Output, E, S>>) -> A,
->(
-    f: F,
-) -> Recursive<Direct<'a, I, A::Output, E, S>> {
+    S: 'a,
+    A: Parser<'a, I, O, E, S> + 'a,
+    F: FnOnce(Recursive<Direct<'a, I, O, E, S>>) -> A,
+{
     let rc = Rc::new_cyclic(|rc| {
-        let rc: Weak<dyn Parser<'a, I, E, S, Output = A::Output>> = rc.clone() as _;
+        let rc: Weak<dyn Parser<'a, I, O, E, S>> = rc.clone() as _;
         let parser = Recursive {
             inner: RecursiveInner::Unowned(rc.clone()),
         };

--- a/src/zero_copy/regex.rs
+++ b/src/zero_copy/regex.rs
@@ -12,7 +12,7 @@ pub fn regex<C: Char, I: ?Sized, E, S>(pattern: &str) -> Regex<C, I, E, S> {
     }
 }
 
-impl<'a, C, I, E, S> Parser<'a, I, E, S> for Regex<C, I, E, S>
+impl<'a, C, I, E, S> Parser<'a, I, &'a C::Slice, E, S> for Regex<C, I, E, S>
 where
     C: Char,
     C::Slice: 'a,
@@ -20,9 +20,7 @@ where
     E: Error<I>,
     S: 'a,
 {
-    type Output = &'a C::Slice;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, &'a C::Slice, E> {
         let before = inp.save();
         C::match_regex(&self.regex, inp.slice_trailing())
             .map(|len| {
@@ -40,5 +38,5 @@ where
             })
     }
 
-    go_extra!();
+    go_extra!(&'a C::Slice);
 }

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -69,17 +69,15 @@ pub struct Padded<A> {
     pub(crate) parser: A,
 }
 
-impl<'a, I, E, S, A> Parser<'a, I, E, S> for Padded<A>
+impl<'a, I, O, E, S, A> Parser<'a, I, O, E, S> for Padded<A>
 where
     I: Input + ?Sized,
     E: Error<I>,
     S: 'a,
     I::Token: Char,
-    A: Parser<'a, I, E, S>,
+    A: Parser<'a, I, O, E, S>,
 {
-    type Output = A::Output;
-
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, Self::Output, E> {
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E> {
         inp.skip_while(|c| c.is_whitespace());
         let out = self.parser.go::<M>(inp)?;
         inp.skip_while(|c| c.is_whitespace());

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -84,5 +84,5 @@ where
         Ok(out)
     }
 
-    go_extra!();
+    go_extra!(O);
 }


### PR DESCRIPTION
Hello @zesterer,

This is a tentative at https://github.com/zesterer/chumsky/issues/9#issuecomment-1292788564 , indeed, it wasn't an easy change,

What I did basically (in a few more steps):
1. Change `zero_copy::Parser` to take `O` generic type, and remove its `Output` associated type. (start review here I think)
2. Go through all errors one by one and fix all combinators, primitives, etc... until `cargo build [...]` is happy.

   I've left a number of `FIXME`s, because I had the error `E0207` (a lot):
   For a code like this (simplified):
   ```rust
   impl<A, OA, ..., O> Parser<.., O, ..> for Map<A, F>
   where
       A: Parser<.., OA, ..>,
       F: Fn(OA) -> O,
       ...
   ```
   I get:
   ``the type parameter `OA` is not constrained by the impl trait, self type, or predicates``
   For some reason the compiler doesn't see that `OA` is used in `A`, which is used for `Map<A, F>` (Am I missing something? Is it a known limitation/bug(?) of the compiler?).
   To fix this I had to add a lot of additional PhantomData to combinator structs (like `Map<A, OA, F>`) to ensure `OA` (and others) are mentioned in either the impl trait or self type.

   Another thing: I didn't understand how to edit the macro `impl_group_for_tuple`, so it's not called for now (commented), I've commited what I thought would work, could you help me with that?

3. Try to run the tests, fix (AFAIK) the callers to use the parsers with the new `O` generic type.
4. => Now I'm blocked at an error I don't understand how to fix...:
```
error[E0599]: the method `or` exists for struct `zero_copy::combinator::MapSlice<zero_copy::combinator::Repeated<zero_copy::combinator::Filter<zero_copy::primitive::Any<_, _, _>, [closure@src/zero_copy/mod.rs:799:21: 799:31]>, char, _, (), _, _>, fn(&str) -> Token<'_> {Token::<'_>::Ident}, _, _>`, but its trait bounds were not satisfied
   --> src/zero_copy/mod.rs:810:14
    |
810 |             .or(string)
    |              ^^ method cannot be called on `zero_copy::combinator::MapSlice<zero_copy::combinator::Repeated<zero_copy::combinator::Filter<zero_copy::primitive::Any<_, _, _>, [closure@src/zero_copy/mod.rs:799:21: 799:31]>, char, _, (), _, _>, fn(&str) -> Token<'_> {Token::<'_>::Ident}, _, _>` due to unsatisfied trait bounds
    |
   ::: src/zero_copy/combinator.rs:5:1
    |
5   | pub struct MapSlice<A, F, E = (), S = ()> {
    | -----------------------------------------
    | |
    | method `or` not found for this struct
    | doesn't satisfy `_: zero_copy::Parser<'_, _, _, _, _>`
    |
note: trait bound `zero_copy::combinator::MapSlice<zero_copy::combinator::Repeated<zero_copy::combinator::Filter<zero_copy::primitive::Any<_, _, _>, [closure@src/zero_copy/mod.rs:799:21: 799:31]>, char, _, (), _, _>, fn(&str) -> Token<'_> {Token::<'_>::Ident}, _, _>: zero_copy::Parser<'_, _, _, _, _>` was not satisfied
   --> src/zero_copy/blanket.rs:5:8
    |
3   | impl<'a, T, I, O, E, S> Parser<'a, I, O, E, S> for &'a T
    |                         ----------------------     -----
4   | where
5   |     T: Parser<'a, I, O, E, S>,
    |        ^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound introduced here
note: the following trait must be implemented
   --> src/zero_copy/mod.rs:177:1
    |
177 | pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
note: `zero_copy::Parser` defines an item `or`, perhaps you need to implement it
   --> src/zero_copy/mod.rs:177:1
    |
177 | pub trait Parser<'a, I: Input + ?Sized, O, E: Error<I> = (), S: 'a = ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
(screenshot for colors)
![image](https://user-images.githubusercontent.com/9730330/201542631-f3f4c1b1-d0be-4668-816b-77e03effd3ce.png)

This errors indicates that `zero_copy::Parser` is not implemented for `zero_copy::combinator::MapSlice`, but it is? The error mentions the blanket impl of `zero_copy::Parser` for all `&'a T`, but I don't understand why this is needed (there's not blanket in master branch afaik), and what is its relation to the error message..

---
I hope this work will be useful to you, at least to start rolling the ball for this, learn what not to do, .. :)

I'm happy to continue working on this if you manage to understand this error / unblock the situation, I learned a lot here!
Please tell me if you see any improvement to the structure of the changes, I'll propagate suggestions as needed.