### PR TITLE
Fix Expr::Then span in nano_rust example

### DIFF
--- a/examples/nano_rust.rs
+++ b/examples/nano_rust.rs
@@ -354,6 +354,8 @@ fn expr_parser() -> impl Parser<Token, Spanned<Expr>, Error = Simple<Token>> + C
             .or(raw_expr.clone())
             .then(just(Token::Ctrl(';')).ignore_then(expr.or_not()).repeated())
             .foldl(|a, b| {
+                // This allows creating a span that covers the entire Then expression.
+                // b_end is the end of b if it exists, otherwise it is the end of a.
                 let a_start = a.1.start;
                 let b_end = b.as_ref().map(|b| b.1.end).unwrap_or(a.1.end);
                 (
@@ -361,6 +363,7 @@ fn expr_parser() -> impl Parser<Token, Spanned<Expr>, Error = Simple<Token>> + C
                         Box::new(a),
                         Box::new(match b {
                             Some(b) => b,
+                            // Since there is no b expression then its span is empty.
                             None => (Expr::Value(Value::Null), b_end..b_end),
                         }),
                     ),

--- a/examples/nano_rust.rs
+++ b/examples/nano_rust.rs
@@ -354,16 +354,17 @@ fn expr_parser() -> impl Parser<Token, Spanned<Expr>, Error = Simple<Token>> + C
             .or(raw_expr.clone())
             .then(just(Token::Ctrl(';')).ignore_then(expr.or_not()).repeated())
             .foldl(|a, b| {
-                let span = a.1.clone(); // TODO: Not correct
+                let a_start = a.1.start;
+                let b_end = b.as_ref().map(|b| b.1.end).unwrap_or(a.1.end);
                 (
                     Expr::Then(
                         Box::new(a),
                         Box::new(match b {
                             Some(b) => b,
-                            None => (Expr::Value(Value::Null), span.clone()),
+                            None => (Expr::Value(Value::Null), b_end..b_end),
                         }),
                     ),
-                    span,
+                    a_start..b_end,
                 )
             })
     })


### PR DESCRIPTION
This sets the Expr::Then span correctly, resolving the only TODO in nano_rust.

Fixes TODO in nano_rust #231