### PR TITLE
Better label merging

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1381,16 +1381,23 @@ impl<I: Clone, O, A: Parser<I, O, Error = E>, L: Into<E::Label> + Clone, E: Erro
         // let pre_state = stream.save();
         #[allow(deprecated)]
         let (errors, res) = debugger.invoke(&self.0, stream);
-        let res = res.map_err(|e| {
-            /* TODO: Not this? */
-            /*if e.at > pre_state
-            {*/
-            // Only add the label if we committed to this pattern somewhat
-            e.map(|e| e.with_label(self.1.clone().into()))
-            /*} else {
-                e
-            }*/
-        });
+        let res = res
+            .map(|(o, alt)| {
+                (
+                    o,
+                    alt.map(|l| l.map(|e| e.with_label(self.1.clone().into()))),
+                )
+            })
+            .map_err(|e| {
+                /* TODO: Not this? */
+                /*if e.at > pre_state
+                {*/
+                // Only add the label if we committed to this pattern somewhat
+                e.map(|e| e.with_label(self.1.clone().into()))
+                /*} else {
+                    e
+                }*/
+            });
         (
             errors
                 .into_iter()


### PR DESCRIPTION
Sequences of `or()` parsers that all fail have their combined errors reported using the label of the first alternative in the list. Similarly, sequences of `then(xyz.or_not())` parsers have their combined errors reported using the last in the sequence.

I wanted these cases to be reported using none of their respective labels, so that a higher level label could be applied to their collective failure. However my first attempt to fix this just in `error::Simple::merge()` using something like `Option::xor` failed, because when processing three `.or()` branches in a row, the first two would have their label collapsed to `None` and then the third would replace the `None` with its own.

To address this issue I added a new type, `SimpleLabel`, which captures the difference between merging with an error with no label, or merging with an error that's already had multiple other labels merged into it.

While debugging this PR I found another issue with `.labelled("...")` branches seemingly not being applied correctly, it turns out that an error can sneak through the `Label<_, _>` parser as an "alternate error", so I've added a second commit to fix this.