### PR TITLE
[zero-copy] Make zero_copy work on stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@
     feature = "nightly",
     feature(
         rustc_attrs,
-        bench_black_box,
-        maybe_uninit_uninit_array,
-        maybe_uninit_array_assume_init,
         once_cell,
     )
 )]
@@ -25,7 +22,6 @@ pub mod recursive;
 pub mod span;
 pub mod stream;
 pub mod text;
-#[cfg(feature = "nightly")]
 pub mod zero_copy;
 
 pub use crate::{error::Error, span::Span};

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -51,7 +51,6 @@ use alloc::{
     vec::Vec,
 };
 use core::{
-    cell::OnceCell,
     cmp::{Eq, Ordering},
     fmt,
     hash::Hash,


### PR DESCRIPTION
Preserves the `OnceCell` workaround from master, and adds a `MaybeUninit` extension for the new array combinators