### PR TITLE
[zero-copy] Minor cleanups

### DIFF
--- a/benches/json.rs
+++ b/benches/json.rs
@@ -50,13 +50,13 @@ fn bench_json(c: &mut Criterion) {
     c.bench_function("chumsky_zero_copy", {
         use ::chumsky::zero_copy::prelude::*;
         let json = chumsky_zero_copy::json();
-        move |b| b.iter(|| black_box(json.parse(JSON).0.unwrap()))
+        move |b| b.iter(|| black_box(json.parse(JSON)).into_result().unwrap())
     });
 
     c.bench_function("chumsky_zero_copy_check", {
         use ::chumsky::zero_copy::prelude::*;
         let json = chumsky_zero_copy::json();
-        move |b| b.iter(|| assert!(black_box(json.check(JSON)).is_empty()))
+        move |b| b.iter(|| assert!(black_box(json.check(JSON)).into_errors().is_empty()))
     });
 }
 

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -801,8 +801,8 @@ where
             let before = inp.save();
             match self.parser.go::<M>(inp) {
                 Ok(out) => {
-                    output = M::map(output, |mut output: C| {
-                        M::map(out, |out| output.push(out));
+                    output = M::combine(output, out, |mut output: C, out| {
+                        output.push(out);
                         output
                     });
                     count += 1;

--- a/src/zero_copy/input.rs
+++ b/src/zero_copy/input.rs
@@ -212,10 +212,12 @@ impl<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> InputRef<'a, 'parse, I, E, S
 
     pub(crate) fn skip_while<F: FnMut(&I::Token) -> bool>(&mut self, mut f: F) {
         loop {
-            let before = self.save();
-            if self.next().1.filter(&mut f).is_none() {
-                self.rewind(before);
-                break;
+            let (offset, token) = self.input.next(self.marker.offset);
+            if token.filter(&mut f).is_none() {
+                break
+            } else {
+                self.marker.offset = offset;
+                self.marker.pos += 1;
             }
         }
     }

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -187,12 +187,15 @@ mod internal {
     pub struct Emit;
     impl Mode for Emit {
         type Output<T> = T;
+        #[inline(always)]
         fn bind<T, F: FnOnce() -> T>(f: F) -> Self::Output<T> {
             f()
         }
+        #[inline(always)]
         fn map<T, U, F: FnOnce(T) -> U>(x: Self::Output<T>, f: F) -> Self::Output<U> {
             f(x)
         }
+        #[inline(always)]
         fn combine<T, U, V, F: FnOnce(T, U) -> V>(
             x: Self::Output<T>,
             y: Self::Output<U>,
@@ -200,10 +203,12 @@ mod internal {
         ) -> Self::Output<V> {
             f(x, y)
         }
+        #[inline(always)]
         fn array<T, const N: usize>(x: [Self::Output<T>; N]) -> Self::Output<[T; N]> {
             x
         }
 
+        #[inline(always)]
         fn invoke<'a, I, O, E, S, P>(
             parser: &P,
             inp: &mut InputRef<'a, '_, I, E, S>,
@@ -221,16 +226,21 @@ mod internal {
     pub struct Check;
     impl Mode for Check {
         type Output<T> = ();
+        #[inline(always)]
         fn bind<T, F: FnOnce() -> T>(_: F) -> Self::Output<T> {}
+        #[inline(always)]
         fn map<T, U, F: FnOnce(T) -> U>(_: Self::Output<T>, _: F) -> Self::Output<U> {}
+        #[inline(always)]
         fn combine<T, U, V, F: FnOnce(T, U) -> V>(
             _: Self::Output<T>,
             _: Self::Output<U>,
             _: F,
         ) -> Self::Output<V> {
         }
+        #[inline(always)]
         fn array<T, const N: usize>(_: [Self::Output<T>; N]) -> Self::Output<[T; N]> {}
 
+        #[inline(always)]
         fn invoke<'a, I, O, E, S, P>(
             parser: &P,
             inp: &mut InputRef<'a, '_, I, E, S>,

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -50,6 +50,7 @@ use alloc::{
     rc::{Rc, Weak},
     string::String,
     vec::Vec,
+    vec,
 };
 use core::{
     cmp::{Eq, Ordering},
@@ -77,7 +78,7 @@ pub type PResult<M, O, E> = Result<<M as Mode>::Output<O>, Located<E>>;
 
 /// The result of running a [`Parser`]. Can be converted into a [`Result`] via
 /// [`ParseResult::into_result`] for when you only care about success or failure, or into distinct
-/// error and output via [`ParseResult::into_tuple`]
+/// error and output via [`ParseResult::into_output_errors`]
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParseResult<T, E> {
     output: Option<T>,
@@ -106,8 +107,8 @@ impl<T, E> ParseResult<T, E> {
 
     /// Get a slice containing the parse errors for this result. The slice will be empty
     /// if there are no errors.
-    pub fn errors(&self) -> &[E] {
-        &self.errs
+    pub fn errors(&self) -> impl ExactSizeIterator<Item = &E> {
+        self.errs.iter()
     }
 
     /// Convert this `ParseResult` into an option containing the output, if any exists


### PR DESCRIPTION
Make benchmarks build again, fix doc link and change `ParseResult::errors` return type, add some inline to trivial functions