### PR TITLE
[zero-copy] Idea: repeat_prefixed for common then_with case

### DIFF
--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -476,25 +476,9 @@ where
     F: Fn(OA) -> B,
 {
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, OB, E> {
-        let before = inp.save();
-        match self.parser.go::<Emit>(inp) {
-            Ok(output) => {
-                let then = (self.then)(output);
-
-                let before = inp.save();
-                match then.go::<M>(inp) {
-                    Ok(output) => Ok(output),
-                    Err(e) => {
-                        inp.rewind(before);
-                        Err(e)
-                    }
-                }
-            }
-            Err(e) => {
-                inp.rewind(before);
-                Err(e)
-            }
-        }
+        let prefix = self.parser.go::<Emit>(inp)?;
+        let then = (self.then)(prefix);
+        then.go::<M>(inp)
     }
 
     go_extra!(OB);

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -611,6 +611,17 @@ impl<A, B, O, C, E, S> RepeatPrefixed<A, B, O, C, E, S> {
     }
 }
 
+impl<A: Copy, B: Copy, O, C, E, S> Copy for RepeatPrefixed<A, B, O, C, E, S> {}
+impl<A: Clone, B: Clone, O, C, E, S> Clone for RepeatPrefixed<A, B, O, C, E, S> {
+    fn clone(&self) -> Self {
+        RepeatPrefixed {
+            prefix: self.prefix.clone(),
+            repeat: self.repeat.clone(),
+            phantom: PhantomData,
+        }
+    }
+}
+
 impl<'a, A, B, I, O, C, E, S> Parser<'a, I, C, E, S> for RepeatPrefixed<A, B, O, C, E, S>
 where
     A: Parser<'a, I, usize, E, S>,


### PR DESCRIPTION
I consider `then_with` something of a chumsky 'worst-case' - it is sometimes needed, but I would much prefer as many cases as possible have alternatives. This PR implements one such alternative - the motivating case for me, length-prefixed parsing. I can't yet think of an amazing API for the more generic case to replace then_with, and I'm not 100% sure this is even a step in the right direction. But implementing it was easy, so I figured I'd put it up for comments

The `ThenWith` change is a drive-by, only parsers that do error handling should really be rewinding, doing so in `ThenWith` has a high chance to muck up error reporting.