### PR TITLE
[zero-copy] Pull container into module, add more impls

### DIFF
--- a/benches/json.rs
+++ b/benches/json.rs
@@ -71,16 +71,14 @@ mod chumsky_zero_copy {
 
     pub fn json<'a>() -> impl Parser<'a, [u8], JsonZero<'a>> {
         recursive(|value| {
-            let digits = any()
-                .filter(|b: &u8| b.is_ascii_digit())
+            let digits = one_of(b'0'..=b'9')
                 .repeated()
                 .slice();
 
-            let int = any()
-                .filter(|b: &u8| b.is_ascii_digit() && *b != b'0')
+            let int = one_of(b'1'..=b'9')
                 .repeated()
                 .at_least(1)
-                .then(any().filter(|b: &u8| b.is_ascii_digit()).repeated())
+                .then(one_of(b'0'..=b'9').repeated())
                 .ignored()
                 .or(just(b'0').ignored())
                 .ignored();
@@ -114,8 +112,7 @@ mod chumsky_zero_copy {
                 .ignored()
                 .boxed();
 
-            let string = any()
-                .filter(|c| *c != b'\\' && *c != b'"')
+            let string = none_of(b"\\\"")
                 .ignored()
                 .or(escape)
                 .repeated()

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -7,29 +7,6 @@
 
 use super::*;
 use core::mem::MaybeUninit;
-use hashbrown::HashSet;
-
-// TODO: Remove this when MaybeUninit transforms to/from arrays stabilize in any form
-trait MaybeUninitExt<T>: Sized {
-    /// Identical to the unstable [`MaybeUninit::uninit_array`]
-    fn uninit_array<const N: usize>() -> [Self; N];
-
-    /// Identical to the unstable [`MaybeUninit::array_assume_init`]
-    unsafe fn array_assume_init<const N: usize>(uninit: [Self; N]) -> [T; N];
-}
-
-impl<T> MaybeUninitExt<T> for MaybeUninit<T> {
-    fn uninit_array<const N: usize>() -> [Self; N] {
-        // SAFETY: Output type is entirely uninhabited - IE, it's made up entirely of `MaybeUninit`
-        unsafe { MaybeUninit::uninit().assume_init() }
-    }
-
-    unsafe fn array_assume_init<const N: usize>(uninit: [Self; N]) -> [T; N] {
-        let out = (&uninit as *const [Self; N] as *const [T; N]).read();
-        core::mem::forget(uninit);
-        out
-    }
-}
 
 /// See [`Parser::map_slice`].
 pub struct MapSlice<'a, A, I, O, E, S, F, U>
@@ -659,66 +636,6 @@ where
     go_extra!(O);
 }
 
-/// A utility trait for types that can be constructed from a series of output values
-pub trait Container<T>: Default {
-    /// Add a value to the end of this container
-    fn push(&mut self, item: T);
-}
-
-impl<T> Container<T> for () {
-    fn push(&mut self, _: T) {}
-}
-
-impl<T> Container<T> for Vec<T> {
-    fn push(&mut self, item: T) {
-        (*self).push(item);
-    }
-}
-
-impl Container<char> for String {
-    fn push(&mut self, item: char) {
-        (*self).push(item)
-    }
-}
-
-impl<K: Eq + Hash, V> Container<(K, V)> for HashMap<K, V> {
-    fn push(&mut self, (key, value): (K, V)) {
-        (*self).insert(key, value);
-    }
-}
-
-#[cfg(feature = "std")]
-impl<K: Eq + Hash, V> Container<(K, V)> for std::collections::HashMap<K, V> {
-    fn push(&mut self, (key, value): (K, V)) {
-        (*self).insert(key, value);
-    }
-}
-
-impl<T: Eq + Hash> Container<T> for HashSet<T> {
-    fn push(&mut self, item: T) {
-        (*self).insert(item);
-    }
-}
-
-#[cfg(feature = "std")]
-impl<T: Eq + Hash> Container<T> for std::collections::HashSet<T> {
-    fn push(&mut self, item: T) {
-        (*self).insert(item);
-    }
-}
-
-impl<K: Ord, V> Container<(K, V)> for alloc::collections::BTreeMap<K, V> {
-    fn push(&mut self, (key, value): (K, V)) {
-        (*self).insert(key, value);
-    }
-}
-
-impl<T: Ord> Container<T> for alloc::collections::BTreeSet<T> {
-    fn push(&mut self, item: T) {
-        (*self).insert(item);
-    }
-}
-
 /// See [`Parser::repeated`].
 // FIXME: why C, E, S have default values?
 pub struct Repeated<A, OA, I: ?Sized, C = (), E = EmptyErr, S = ()> {
@@ -1296,56 +1213,6 @@ where
     }
 
     go_extra!(OA);
-}
-
-/// A utility trait for types that hold a specific constant number of input values
-pub trait ContainerExactly<T, const N: usize> {
-    /// An uninitialized value of this container
-    type Uninit;
-
-    /// Get an uninitialized form of this container
-    fn uninit() -> Self::Uninit;
-
-    /// Write a value to a position in an uninitialized container
-    fn write(uninit: &mut Self::Uninit, i: usize, item: T);
-
-    /// Drop all values before a provided index in this container
-    ///
-    /// # Safety
-    ///
-    /// All values must be initialized, up to the provided index
-    unsafe fn drop_before(uninit: &mut Self::Uninit, i: usize);
-
-    /// Convert this container into its initialized form
-    ///
-    /// # Safety
-    ///
-    /// All values in the container must be initialized
-    unsafe fn take(uninit: Self::Uninit) -> Self;
-}
-
-impl<T, const N: usize> ContainerExactly<T, N> for () {
-    type Uninit = ();
-    fn uninit() -> Self::Uninit {}
-    fn write(_: &mut Self::Uninit, _: usize, _: T) {}
-    unsafe fn drop_before(_: &mut Self::Uninit, _: usize) {}
-    unsafe fn take(_: Self::Uninit) -> Self {}
-}
-
-impl<T, const N: usize> ContainerExactly<T, N> for [T; N] {
-    type Uninit = [MaybeUninit<T>; N];
-    fn uninit() -> Self::Uninit {
-        MaybeUninitExt::uninit_array()
-    }
-    fn write(uninit: &mut Self::Uninit, i: usize, item: T) {
-        uninit[i].write(item);
-    }
-    unsafe fn drop_before(uninit: &mut Self::Uninit, i: usize) {
-        uninit[..i].iter_mut().for_each(|o| o.assume_init_drop());
-    }
-    unsafe fn take(uninit: Self::Uninit) -> Self {
-        MaybeUninitExt::array_assume_init(uninit)
-    }
 }
 
 /// See [`Parser::repeated_exactly`].

--- a/src/zero_copy/container.rs
+++ b/src/zero_copy/container.rs
@@ -333,58 +333,71 @@ impl<T: Ord> Seq<T> for alloc::collections::BTreeSet<T> {
     }
 }
 
-macro_rules! impl_for_range {
-    ($($ty:ty),* $(,)?) => {
-        $(
-        impl Seq<$ty> for Range<$ty> {
-            type Item<'a> = $ty
-            where
-                Self: 'a;
+impl<T> Seq<T> for Range<T>
+where
+    T: Clone + PartialOrd, // Explicit declaration of an implied truth - `Step` requires these
+    Self: Iterator<Item = T>,
+{
+    type Item<'a> = T
+    where
+        Self: 'a;
 
-            type Iter<'a> = Range<$ty>
-            where
-                Self: 'a;
+    type Iter<'a> = Range<T>
+    where
+        Self: 'a;
 
-            fn seq_iter(&self) -> Self::Iter<'_> {
-                self.clone()
-            }
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        (*self).clone()
+    }
 
-            fn contains(&self, val: &$ty) -> bool {
-                Range::contains(self, val)
-            }
-        }
-
-        impl Seq<$ty> for core::ops::RangeInclusive<$ty> {
-            type Item<'a> = $ty
-            where
-                Self: 'a;
-
-            type Iter<'a> = core::ops::RangeInclusive<$ty>
-            where
-                Self: 'a;
-
-            fn seq_iter(&self) -> Self::Iter<'_> {
-                self.clone()
-            }
-
-            fn contains(&self, val: &$ty) -> bool {
-                core::ops::RangeInclusive::contains(self, val)
-            }
-        }
-
-        // TODO: Other range types
-
-        impl OrderedSeq<$ty> for Range<$ty> {}
-        impl OrderedSeq<$ty> for core::ops::RangeInclusive<$ty> {}
-        )*
+    fn contains(&self, val: &T) -> bool {
+        Range::contains(self, val)
     }
 }
 
-impl_for_range!(
-    u8, u16, u32, u64, usize,
-    i8, i16, i32, i64, isize,
-    char,
-);
+impl<T> Seq<T> for core::ops::RangeInclusive<T>
+where
+    T: Clone + PartialOrd,
+    Self: Iterator<Item = T>,
+{
+    type Item<'a> = T
+    where
+        Self: 'a;
+
+    type Iter<'a> = core::ops::RangeInclusive<T>
+    where
+        Self: 'a;
+
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.clone()
+    }
+
+    fn contains(&self, val: &T) -> bool {
+        core::ops::RangeInclusive::contains(self, val)
+    }
+}
+
+impl<T> Seq<T> for RangeFrom<T>
+where
+    T: Clone + PartialOrd,
+    Self: Iterator<Item = T>,
+{
+    type Item<'a> = T
+    where
+        Self: 'a;
+
+    type Iter<'a> = RangeFrom<T>
+    where
+        Self: 'a;
+
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.clone()
+    }
+
+    fn contains(&self, val: &T) -> bool {
+        RangeFrom::contains(self, val)
+    }
+}
 
 impl Seq<char> for str {
     type Item<'a> = char
@@ -450,6 +463,18 @@ impl<'b, T: Clone> OrderedSeq<T> for &'b [T] {}
 impl<T: Clone, const N: usize> OrderedSeq<T> for [T; N] {}
 impl<'b, T: Clone, const N: usize> OrderedSeq<T> for &'b [T; N] {}
 impl<'b, T: Clone> OrderedSeq<T> for Vec<T> {}
+impl<T> OrderedSeq<T> for Range<T>
+where
+    Self: Seq<T>,
+{}
+impl<T> OrderedSeq<T> for core::ops::RangeInclusive<T>
+where
+    Self: Seq<T>,
+{}
+impl<T> OrderedSeq<T> for RangeFrom<T>
+where
+    Self: Seq<T>,
+{}
 
 impl OrderedSeq<char> for str {}
 impl<'b> OrderedSeq<char> for &'b str {}

--- a/src/zero_copy/container.rs
+++ b/src/zero_copy/container.rs
@@ -1,0 +1,324 @@
+//! TODO
+
+use super::*;
+use alloc::collections::LinkedList;
+use hashbrown::HashSet;
+
+/// A utility trait for types that can be constructed from a series of output values
+pub trait Container<T>: Default {
+    /// Add a value to the end of this container
+    fn push(&mut self, item: T);
+}
+
+impl<T> Container<T> for () {
+    fn push(&mut self, _: T) {}
+}
+
+impl<T> Container<T> for Vec<T> {
+    fn push(&mut self, item: T) {
+        (*self).push(item);
+    }
+}
+
+impl<T> Container<T> for LinkedList<T> {
+    fn push(&mut self, item: T) {
+        (*self).push_back(item);
+    }
+}
+
+impl Container<char> for String {
+    fn push(&mut self, item: char) {
+        (*self).push(item)
+    }
+}
+
+impl<K: Eq + Hash, V> Container<(K, V)> for HashMap<K, V> {
+    fn push(&mut self, (key, value): (K, V)) {
+        (*self).insert(key, value);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<K: Eq + Hash, V> Container<(K, V)> for std::collections::HashMap<K, V> {
+    fn push(&mut self, (key, value): (K, V)) {
+        (*self).insert(key, value);
+    }
+}
+
+impl<T: Eq + Hash> Container<T> for HashSet<T> {
+    fn push(&mut self, item: T) {
+        (*self).insert(item);
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: Eq + Hash> Container<T> for std::collections::HashSet<T> {
+    fn push(&mut self, item: T) {
+        (*self).insert(item);
+    }
+}
+
+impl<K: Ord, V> Container<(K, V)> for alloc::collections::BTreeMap<K, V> {
+    fn push(&mut self, (key, value): (K, V)) {
+        (*self).insert(key, value);
+    }
+}
+
+impl<T: Ord> Container<T> for alloc::collections::BTreeSet<T> {
+    fn push(&mut self, item: T) {
+        (*self).insert(item);
+    }
+}
+
+/// A utility trait for types that hold a specific constant number of input values
+pub trait ContainerExactly<T, const N: usize> {
+    /// An uninitialized value of this container
+    type Uninit;
+
+    /// Get an uninitialized form of this container
+    fn uninit() -> Self::Uninit;
+
+    /// Write a value to a position in an uninitialized container
+    fn write(uninit: &mut Self::Uninit, i: usize, item: T);
+
+    /// Drop all values before a provided index in this container
+    ///
+    /// # Safety
+    ///
+    /// All values must be initialized, up to the provided index
+    unsafe fn drop_before(uninit: &mut Self::Uninit, i: usize);
+
+    /// Convert this container into its initialized form
+    ///
+    /// # Safety
+    ///
+    /// All values in the container must be initialized
+    unsafe fn take(uninit: Self::Uninit) -> Self;
+}
+
+impl<T, const N: usize> ContainerExactly<T, N> for () {
+    type Uninit = ();
+    fn uninit() -> Self::Uninit {}
+    fn write(_: &mut Self::Uninit, _: usize, _: T) {}
+    unsafe fn drop_before(_: &mut Self::Uninit, _: usize) {}
+    unsafe fn take(_: Self::Uninit) -> Self {}
+}
+
+impl<T, const N: usize> ContainerExactly<T, N> for [T; N] {
+    type Uninit = [MaybeUninit<T>; N];
+    fn uninit() -> Self::Uninit {
+        MaybeUninitExt::uninit_array()
+    }
+    fn write(uninit: &mut Self::Uninit, i: usize, item: T) {
+        uninit[i].write(item);
+    }
+    unsafe fn drop_before(uninit: &mut Self::Uninit, i: usize) {
+        uninit[..i].iter_mut().for_each(|o| o.assume_init_drop());
+    }
+    unsafe fn take(uninit: Self::Uninit) -> Self {
+        MaybeUninitExt::array_assume_init(uninit)
+    }
+}
+
+/// A utility trait to abstract over container-like things.
+///
+/// This trait is likely to change in future versions of the crate, so avoid implementing it yourself.
+pub trait Seq<T> {
+    /// The item yielded by the iterator
+    type Item<'a>: core::borrow::Borrow<T>
+    where
+        Self: 'a;
+    /// An iterator over the items within this container, by reference.
+    type Iter<'a>: Iterator<Item = Self::Item<'a>>
+    where
+        Self: 'a;
+    /// Iterate over the elements of the container.
+    fn seq_iter(&self) -> Self::Iter<'_>;
+}
+
+impl<T> Seq<T> for T {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+
+    type Iter<'a> = core::iter::Once<&'a T>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        core::iter::once(self)
+    }
+}
+
+impl<'b, T> Seq<T> for &'b [T] {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+    type Iter<'a> = core::slice::Iter<'a, T>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        (self as &[T]).iter()
+    }
+}
+
+impl<T, const N: usize> Seq<T> for [T; N] {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+    type Iter<'a> = core::slice::Iter<'a, T>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.iter()
+    }
+}
+
+impl<'b, T, const N: usize> Seq<T> for &'b [T; N] {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+    type Iter<'a> = core::slice::Iter<'a, T>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.iter()
+    }
+}
+
+impl<'b, T> Seq<T> for Vec<T> {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+    type Iter<'a> = core::slice::Iter<'a, T>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.iter()
+    }
+}
+
+impl<'b, T> Seq<T> for LinkedList<T> {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+    type Iter<'a> = alloc::collections::linked_list::Iter<'a, T>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.iter()
+    }
+}
+
+impl<T> Seq<T> for HashSet<T> {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+    type Iter<'a> = hashbrown::hash_set::Iter<'a, T>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.iter()
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> Seq<T> for std::collections::HashSet<T> {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+    type Iter<'a> = std::collections::hash_set::Iter<'a, T>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.iter()
+    }
+}
+
+impl<T: Ord> Seq<T> for alloc::collections::BTreeSet<T> {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+    type Iter<'a> = alloc::collections::btree_set::Iter<'a, T>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.iter()
+    }
+}
+
+macro_rules! impl_for_range {
+    ($($ty:ty),* $(,)?) => {
+        $(
+        impl Seq<$ty> for Range<$ty> {
+            type Item<'a> = $ty
+            where
+                Self: 'a;
+            type Iter<'a> = Range<$ty>
+            where
+                Self: 'a;
+            fn seq_iter(&self) -> Self::Iter<'_> {
+                self.clone()
+            }
+        }
+
+        impl OrderedSeq<$ty> for Range<$ty> {}
+        )*
+    }
+}
+
+impl_for_range!(
+    u8, u16, u32, u64, usize,
+    i8, i16, i32, i64, isize,
+    char,
+);
+
+impl Seq<char> for str {
+    type Item<'a> = char
+    where
+        Self: 'a;
+    type Iter<'a> = core::str::Chars<'a>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.chars()
+    }
+}
+
+impl<'b> Seq<char> for &'b str {
+    type Item<'a> = char
+    where
+        Self: 'a;
+    type Iter<'a> = core::str::Chars<'a>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.chars()
+    }
+}
+
+impl Seq<char> for String {
+    type Item<'a> = char
+    where
+        Self: 'a;
+    type Iter<'a> = core::str::Chars<'a>
+    where
+        Self: 'a;
+    fn seq_iter(&self) -> Self::Iter<'_> {
+        self.chars()
+    }
+}
+
+/// A utility trait to abstract over *linear* container-like things.
+///
+/// This trait is likely to change in future versions of the crate, so avoid implementing it yourself.
+pub trait OrderedSeq<T>: Seq<T> {}
+
+impl<T: Clone> OrderedSeq<T> for T {}
+impl<'b, T: Clone> OrderedSeq<T> for &'b [T] {}
+impl<T: Clone, const N: usize> OrderedSeq<T> for [T; N] {}
+impl<'b, T: Clone, const N: usize> OrderedSeq<T> for &'b [T; N] {}
+impl<'b, T: Clone> OrderedSeq<T> for Vec<T> {}
+
+impl OrderedSeq<char> for str {}
+impl<'b> OrderedSeq<char> for &'b str {}
+impl OrderedSeq<char> for String {}

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -254,7 +254,7 @@ where
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, I::Token, E> {
         let before = inp.save();
         match inp.next() {
-            (_, Some(tok)) if self.seq.seq_iter().any(|not| *not.borrow() == tok) => Ok(M::bind(|| tok)),
+            (_, Some(tok)) if self.seq.contains(&tok) => Ok(M::bind(|| tok)),
             (at, found) => Err(Located::at(
                 at,
                 E::expected_found(self.seq.seq_iter().map(|not| Some(not.borrow().clone())), found, inp.span_since(before)),
@@ -322,7 +322,7 @@ where
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, I::Token, E> {
         let before = inp.save();
         match inp.next() {
-            (_, Some(tok)) if self.seq.seq_iter().all(|not| *not.borrow() != tok) => Ok(M::bind(|| tok)),
+            (_, Some(tok)) if !self.seq.contains(&tok) => Ok(M::bind(|| tok)),
             (at, found) => Err(Located::at(
                 at,
                 E::expected_found(None, found, inp.span_since(before)),

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -234,8 +234,8 @@ pub const fn one_of<T, I, E, S>(seq: T) -> OneOf<T, I, E, S>
 where
     I: Input + ?Sized,
     E: Error<I>,
-    I::Token: PartialEq,
-    T: Seq<I::Token> + Clone,
+    I::Token: Clone + PartialEq,
+    T: Seq<I::Token>,
 {
     OneOf {
         seq,
@@ -303,7 +303,7 @@ where
     I: Input + ?Sized,
     E: Error<I>,
     I::Token: PartialEq,
-    T: Seq<I::Token> + Clone,
+    T: Seq<I::Token>,
 {
     NoneOf {
         seq,


### PR DESCRIPTION
We do a little bit of `Seq` optimization. This also lets us relax a couple bounds on some primitives. Overall, the change should be pretty minimal, but it should improve performance more the more expensive cloning the tokens/containers was. (benchmarks on my machine say this is only about a 1% win for json, but it does seem to be pretty consistently a little faster)