### PR TITLE
[zero-copy] stabilize InputRef

### DIFF
--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -140,7 +140,7 @@ where
             } else {
                 let span = inp.span_since(before);
                 Err(Located::at(
-                    inp.last_pos(),
+                    inp.save(),
                     E::expected_found(None, None, span),
                 ))
             }
@@ -256,7 +256,7 @@ where
             let span = inp.span_since(before);
             match (self.mapper)(out, span) {
                 Ok(out) => Ok(M::bind(|| out)),
-                Err(e) => Err(Located::at(inp.last_pos(), e)),
+                Err(e) => Err(Located::at(inp.save(), e)),
             }
         })
     }
@@ -287,7 +287,7 @@ where
             let state = inp.state();
             match (self.mapper)(out, span, state) {
                 Ok(out) => Ok(M::bind(|| out)),
-                Err(e) => Err(Located::at(inp.last_pos(), e)),
+                Err(e) => Err(Located::at(inp.save(), e)),
             }
         })
     }

--- a/src/zero_copy/input.rs
+++ b/src/zero_copy/input.rs
@@ -198,10 +198,10 @@ impl<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> InputRef<'a, 'parse, I, E, S
         }
     }
 
-    pub(crate) fn save(&mut self) -> Marker<I> {
+    pub fn save(&mut self) -> Marker<I> {
         self.marker
     }
-    pub(crate) fn rewind(&mut self, marker: Marker<I>) {
+    pub fn rewind(&mut self, marker: Marker<I>) {
         self.errors.truncate(marker.err_count);
         self.marker = marker;
     }
@@ -222,7 +222,7 @@ impl<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> InputRef<'a, 'parse, I, E, S
         }
     }
 
-    pub(crate) fn next(&mut self) -> (usize, Option<I::Token>) {
+    pub fn next(&mut self) -> (usize, Option<I::Token>) {
         let (offset, token) = self.input.next(self.marker.offset);
         self.marker.offset = offset;
         self.marker.pos += 1;
@@ -254,7 +254,7 @@ impl<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> InputRef<'a, 'parse, I, E, S
         self.input.slice_from(self.marker.offset..)
     }
 
-    pub(crate) fn span_since(&self, before: Marker<I>) -> I::Span {
+    pub fn span_since(&self, before: Marker<I>) -> I::Span {
         self.input.span(before.offset..self.marker.offset)
     }
 

--- a/src/zero_copy/input.rs
+++ b/src/zero_copy/input.rs
@@ -162,9 +162,9 @@ where
 {
 }
 
-// Represents the progress of a parser through the input
-pub(crate) struct Marker<I: Input + ?Sized> {
-    pos: usize,
+/// Represents the progress of a parser through the input
+pub struct Marker<I: Input + ?Sized> {
+    pub(crate) pos: usize,
     offset: I::Offset,
     err_count: usize,
 }
@@ -198,9 +198,12 @@ impl<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> InputRef<'a, 'parse, I, E, S
         }
     }
 
+    /// Save off a [`Marker`] to the current position in the input
     pub fn save(&mut self) -> Marker<I> {
         self.marker
     }
+
+    /// Reset the input state to the provided [`Marker`]
     pub fn rewind(&mut self, marker: Marker<I>) {
         self.errors.truncate(marker.err_count);
         self.marker = marker;
@@ -222,15 +225,16 @@ impl<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> InputRef<'a, 'parse, I, E, S
         }
     }
 
-    pub fn next(&mut self) -> (usize, Option<I::Token>) {
+    pub(crate) fn next(&mut self) -> (Marker<I>, Option<I::Token>) {
         let (offset, token) = self.input.next(self.marker.offset);
         self.marker.offset = offset;
         self.marker.pos += 1;
-        (self.marker.pos, token)
+        (self.marker, token)
     }
 
-    pub(crate) fn last_pos(&self) -> usize {
-        self.marker.pos
+    /// Get the next token in the input. Returns `None` for EOI
+    pub fn next_token(&mut self) -> Option<I::Token> {
+        self.next().1
     }
 
     pub(crate) fn slice(&self, range: Range<Marker<I>>) -> &'a I::Slice
@@ -254,6 +258,7 @@ impl<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> InputRef<'a, 'parse, I, E, S
         self.input.slice_from(self.marker.offset..)
     }
 
+    /// Return the span from the provided [`Marker`] to the current position
     pub fn span_since(&self, before: Marker<I>) -> I::Span {
         self.input.span(before.offset..self.marker.offset)
     }

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -664,7 +664,7 @@ macro_rules! impl_choice_for_tuple {
                     };
                 )*
 
-                Err(err.unwrap_or_else(|| Located::at(inp.last_pos(), E::expected_found(None, None, inp.span_since(before)))))
+                Err(err.unwrap_or_else(|| Located::at(inp.save(), E::expected_found(None, None, inp.span_since(before)))))
             }
 
             go_extra!(O);


### PR DESCRIPTION
Makes public the minimal API for custom parsers - no state access, non non-terminal errors, but you can parse, recover, and error correctly.