### PR TITLE
[zero-copy] Replace `E: Error<I>, S: 'a` with `E: ParserExtra<'a, I>`

### DIFF
--- a/src/zero_copy/blanket.rs
+++ b/src/zero_copy/blanket.rs
@@ -1,13 +1,12 @@
 use super::*;
 
-impl<'a, T, I, O, E, S> Parser<'a, I, O, E, S> for &'a T
+impl<'a, T, I, O, E> Parser<'a, I, O, E> for &'a T
 where
-    T: Parser<'a, I, O, E, S>,
+    T: Parser<'a, I, O, E>,
     I: Input + ?Sized,
-    E: Error<I>,
-    S: 'a,
+    E: ParserExtra<'a, I>,
 {
-    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E, S>) -> PResult<M, O, E>
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error>
     where
         Self: Sized,
     {

--- a/src/zero_copy/error.rs
+++ b/src/zero_copy/error.rs
@@ -48,7 +48,7 @@ use alloc::string::ToString;
 ///     }
 /// }
 ///
-/// let numeral = any::<_, _, ()>().try_map(|c: char, span| match c.to_digit(10) {
+/// let numeral = any::<_, extra::Err<MyError>>().try_map(|c: char, span| match c.to_digit(10) {
 ///     Some(x) => Ok(x),
 ///     None => Err(MyError::NotADigit(span, c)),
 /// });

--- a/src/zero_copy/extra.rs
+++ b/src/zero_copy/extra.rs
@@ -6,62 +6,35 @@ mod internal {
     use super::*;
 
     pub trait ExtraSealed {}
-
-    impl ExtraSealed for ExtraDefault {}
-    impl<E> ExtraSealed for Err<E> {}
-    impl<S> ExtraSealed for State<S> {}
     impl<E, S> ExtraSealed for Full<E, S> {}
 }
 
 use internal::ExtraSealed;
 
-/// TODO
+type DefaultErr = EmptyErr;
+type DefaultState = ();
+
+/// Sealed trait for parser extra information - error type, state type, etc.
 pub trait ParserExtra<'a, I>: 'a + ExtraSealed
 where
     I: ?Sized + Input,
 {
-    /// TODO
+    /// Error type to use for the parser
     type Error: Error<I> + 'a;
-    /// TODO
+    /// State type to use for the parser
     type State: 'a;
 }
 
-/// TODO
-pub struct ExtraDefault;
+/// Use all default extra types
+pub type Default = Full<DefaultErr, DefaultState>;
 
-impl<'a, I> ParserExtra<'a, I> for ExtraDefault
-where
-    I: ?Sized + Input,
-{
-    type Error = EmptyErr;
-    type State = ();
-}
+/// Use specified error type, but default other types
+pub type Err<E> = Full<E, DefaultState>;
 
-/// TODO
-pub struct Err<E>(PhantomData<E>);
+/// Use specified state type, but default other types
+pub type State<S> = Full<DefaultErr, S>;
 
-impl<'a, I, E> ParserExtra<'a, I> for Err<E>
-where
-    I: ?Sized + Input,
-    E: Error<I> + 'a,
-{
-    type Error = E;
-    type State = ();
-}
-
-/// TODO
-pub struct State<S>(PhantomData<S>);
-
-impl<'a, I, S> ParserExtra<'a, I> for State<S>
-where
-    I: ?Sized + Input,
-    S: 'a,
-{
-    type Error = EmptyErr;
-    type State = S;
-}
-
-/// TODO
+/// Specify all extra types
 pub struct Full<E, S>(PhantomData<(E, S)>);
 
 impl<'a, I, E, S> ParserExtra<'a, I> for Full<E, S>

--- a/src/zero_copy/extra.rs
+++ b/src/zero_copy/extra.rs
@@ -1,0 +1,75 @@
+//! TODO
+
+use super::*;
+
+mod internal {
+    use super::*;
+
+    pub trait ExtraSealed {}
+
+    impl ExtraSealed for ExtraDefault {}
+    impl<E> ExtraSealed for Err<E> {}
+    impl<S> ExtraSealed for State<S> {}
+    impl<E, S> ExtraSealed for Full<E, S> {}
+}
+
+use internal::ExtraSealed;
+
+/// TODO
+pub trait ParserExtra<'a, I>: 'a + ExtraSealed
+where
+    I: ?Sized + Input,
+{
+    /// TODO
+    type Error: Error<I> + 'a;
+    /// TODO
+    type State: 'a;
+}
+
+/// TODO
+pub struct ExtraDefault;
+
+impl<'a, I> ParserExtra<'a, I> for ExtraDefault
+where
+    I: ?Sized + Input,
+{
+    type Error = EmptyErr;
+    type State = ();
+}
+
+/// TODO
+pub struct Err<E>(PhantomData<E>);
+
+impl<'a, I, E> ParserExtra<'a, I> for Err<E>
+where
+    I: ?Sized + Input,
+    E: Error<I> + 'a,
+{
+    type Error = E;
+    type State = ();
+}
+
+/// TODO
+pub struct State<S>(PhantomData<S>);
+
+impl<'a, I, S> ParserExtra<'a, I> for State<S>
+where
+    I: ?Sized + Input,
+    S: 'a,
+{
+    type Error = EmptyErr;
+    type State = S;
+}
+
+/// TODO
+pub struct Full<E, S>(PhantomData<(E, S)>);
+
+impl<'a, I, E, S> ParserExtra<'a, I> for Full<E, S>
+where
+    I: ?Sized + Input,
+    E: Error<I> + 'a,
+    S: 'a,
+{
+    type Error = E;
+    type State = S;
+}

--- a/src/zero_copy/input.rs
+++ b/src/zero_copy/input.rs
@@ -177,15 +177,15 @@ impl<I: Input + ?Sized> Clone for Marker<I> {
 }
 
 /// Internal type representing an input as well as all the necessary context for parsing.
-pub struct InputRef<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> {
+pub struct InputRef<'a, 'parse, I: Input + ?Sized, E: ParserExtra<'a, I>> {
     input: &'a I,
     marker: Marker<I>,
-    state: &'parse mut S,
-    errors: Vec<E>,
+    state: &'parse mut E::State,
+    errors: Vec<E::Error>,
 }
 
-impl<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> InputRef<'a, 'parse, I, E, S> {
-    pub(crate) fn new(input: &'a I, state: &'parse mut S) -> Self {
+impl<'a, 'parse, I: Input + ?Sized, E: ParserExtra<'a, I>> InputRef<'a, 'parse, I, E> {
+    pub(crate) fn new(input: &'a I, state: &'parse mut E::State) -> Self {
         Self {
             input,
             marker: Marker {
@@ -209,7 +209,7 @@ impl<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> InputRef<'a, 'parse, I, E, S
         self.marker = marker;
     }
 
-    pub(crate) fn state(&mut self) -> &mut S {
+    pub(crate) fn state(&mut self) -> &mut E::State {
         self.state
     }
 
@@ -271,12 +271,12 @@ impl<'a, 'parse, I: Input + ?Sized, E: Error<I>, S> InputRef<'a, 'parse, I, E, S
         self.marker.offset += skip;
     }
 
-    pub(crate) fn emit(&mut self, error: E) {
+    pub(crate) fn emit(&mut self, error: E::Error) {
         self.errors.push(error);
         self.marker.err_count += 1;
     }
 
-    pub(crate) fn into_errs(self) -> Vec<E> {
+    pub(crate) fn into_errs(self) -> Vec<E::Error> {
         self.errors
     }
 }

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -73,7 +73,7 @@ use self::{
     combinator::*,
     container::*,
     error::{Error, EmptyErr},
-    extra::{ParserExtra, ExtraDefault},
+    extra::ParserExtra,
     input::{Input, InputRef, Marker, SliceInput, StrInput},
     span::{Span, SimpleSpan},
     text::*,
@@ -330,7 +330,7 @@ pub use internal::{Mode, Emit, Check};
         note = "You should check that the output types of your parsers are consistent with combinator you're using",
     )
 )]
-pub trait Parser<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I> = ExtraDefault> {
+pub trait Parser<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I> = extra::Default> {
     /// Parse a stream of tokens, yielding an output if possible, and any errors encountered along the way.
     ///
     /// If `None` is returned (i.e: parsing failed) then there will *always* be at least one item in the error `Vec`.


### PR DESCRIPTION
This implements the idea from #261 for improving generics in `Parser` - this may also help if, in the future, we want to split `Parser` into sub-crates for things like state and context, since then we could only require `Error` by default and add extra bounds for `State` or `Context`. It also cleans up a lot of generic signatures.

On the other hand, it's definitely a major change, and the naming may not be the best. I don't know if this is the desired path forwards, but I figured I'd put this up for opinions.