### PR TITLE
[zero-copy] Implement `E::Context` and `Parser::Config` - parse-time control of parser parameters

### DIFF
--- a/examples/indent.rs
+++ b/examples/indent.rs
@@ -10,7 +10,7 @@ fn parser<'a>() -> impl Parser<'a, str, Vec<Stmt>> {
     let expr = just("expr"); // TODO
 
     let block = recursive(|block| {
-        let indent = any().filter(|c| *c == ' ')
+        let indent = any().filter(|c: &char| *c == ' ')
             .repeated()
             .configure(|cfg, parent_indent| cfg.exactly(*parent_indent));
 

--- a/examples/indent.rs
+++ b/examples/indent.rs
@@ -1,0 +1,52 @@
+use chumsky::zero_copy::prelude::*;
+
+#[derive(Clone, Debug)]
+enum Stmt {
+    Expr,
+    Loop(Vec<Stmt>),
+}
+
+fn parser<'a>() -> impl Parser<'a, str, Vec<Stmt>> {
+    let expr = just("expr"); // TODO
+
+    let block = recursive(|block| {
+        let indent = any().filter(|c| *c == ' ')
+            .repeated()
+            .configure(|cfg, parent_indent| cfg.exactly(*parent_indent));
+
+        let expr_stmt = expr
+            .then_ignore(text::newline())
+            .to(Stmt::Expr);
+        let control_flow = just("loop:")
+            .then(text::newline())
+            .ignore_then(block).map(Stmt::Loop);
+        let stmt = expr_stmt.or(control_flow);
+
+        text::whitespace().count()
+            .then_with_ctx(stmt
+                .separated_by(indent)
+                .collect::<Vec<_>>(), |a, b| a)
+    });
+
+    // empty().then_with_ctx(block, |_: (), _: &()| 0)
+    Parser::<_, _>::then_with_ctx(empty(), block, |_, _| 0)
+}
+
+fn main() {
+    let stmts = parser()
+        .padded()
+        .then_ignore(end())
+        .parse(r#"
+expr
+expr
+loop:
+    expr
+    loop:
+        expr
+        expr
+    expr
+expr
+"#);
+    println!("{:#?}", stmts.output());
+    println!("{:?}", stmts.errors().collect::<Vec<_>>());
+}

--- a/examples/indent.rs
+++ b/examples/indent.rs
@@ -25,11 +25,10 @@ fn parser<'a>() -> impl Parser<'a, str, Vec<Stmt>> {
         text::whitespace().count()
             .then_with_ctx(stmt
                 .separated_by(indent)
-                .collect::<Vec<_>>(), |a, b| a)
+                .collect())
     });
 
-    // empty().then_with_ctx(block, |_: (), _: &()| 0)
-    Parser::<_, _>::then_with_ctx(empty(), block, |_, _| 0)
+    block.with_ctx(0)
 }
 
 fn main() {

--- a/examples/indent.rs
+++ b/examples/indent.rs
@@ -10,32 +10,29 @@ fn parser<'a>() -> impl Parser<'a, str, Vec<Stmt>> {
     let expr = just("expr"); // TODO
 
     let block = recursive(|block| {
-        let indent = any().filter(|c: &char| *c == ' ')
+        let indent = any()
+            .filter(|c: &char| *c == ' ')
             .repeated()
             .configure(|cfg, parent_indent| cfg.exactly(*parent_indent));
 
-        let expr_stmt = expr
-            .then_ignore(text::newline())
-            .to(Stmt::Expr);
+        let expr_stmt = expr.then_ignore(text::newline()).to(Stmt::Expr);
         let control_flow = just("loop:")
             .then(text::newline())
-            .ignore_then(block).map(Stmt::Loop);
+            .ignore_then(block)
+            .map(Stmt::Loop);
         let stmt = expr_stmt.or(control_flow);
 
-        text::whitespace().count()
-            .then_with_ctx(stmt
-                .separated_by(indent)
-                .collect())
+        text::whitespace()
+            .count()
+            .then_with_ctx(stmt.separated_by(indent).collect())
     });
 
     block.with_ctx(0)
 }
 
 fn main() {
-    let stmts = parser()
-        .padded()
-        .then_ignore(end())
-        .parse(r#"
+    let stmts = parser().padded().then_ignore(end()).parse(
+        r#"
 expr
 expr
 loop:
@@ -45,7 +42,8 @@ loop:
         expr
     expr
 expr
-"#);
+"#,
+    );
     println!("{:#?}", stmts.output());
     println!("{:?}", stmts.errors().collect::<Vec<_>>());
 }

--- a/src/zero_copy/blanket.rs
+++ b/src/zero_copy/blanket.rs
@@ -6,11 +6,20 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
+    type Config = T::Config;
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error>
     where
         Self: Sized,
     {
         (*self).go::<M>(inp)
+    }
+
+    fn go_cfg<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<M, O, E::Error>
+    where
+        Self: Sized,
+    {
+        (*self).go_cfg::<M>(inp, cfg)
     }
 
     go_extra!(O);

--- a/src/zero_copy/blanket.rs
+++ b/src/zero_copy/blanket.rs
@@ -6,7 +6,6 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error>
     where
         Self: Sized,
@@ -25,7 +24,11 @@ where
 {
     type Config = T::Config;
 
-    fn go_cfg<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<M, O, E::Error>
+    fn go_cfg<M: Mode>(
+        &self,
+        inp: &mut InputRef<'a, '_, I, E>,
+        cfg: Self::Config,
+    ) -> PResult<M, O, E::Error>
     where
         Self: Sized,
     {

--- a/src/zero_copy/blanket.rs
+++ b/src/zero_copy/blanket.rs
@@ -6,7 +6,6 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
-    type Config = T::Config;
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error>
     where
@@ -15,6 +14,17 @@ where
         (*self).go::<M>(inp)
     }
 
+    go_extra!(O);
+}
+
+impl<'a, T, I, O, E> ConfigParser<'a, I, O, E> for &'a T
+where
+    T: ConfigParser<'a, I, O, E>,
+    I: Input + ?Sized,
+    E: ParserExtra<'a, I>,
+{
+    type Config = T::Config;
+
     fn go_cfg<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<M, O, E::Error>
     where
         Self: Sized,
@@ -22,5 +32,5 @@ where
         (*self).go_cfg::<M>(inp, cfg)
     }
 
-    go_extra!(O);
+    go_cfg_extra!(O);
 }

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -32,8 +32,8 @@ where
     E: ParserExtra<'a, I>,
 {
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error>
-        where
-            Self: Sized,
+    where
+        Self: Sized,
     {
         let cfg = (self.cfg)(A::Config::default(), inp.ctx());
         self.parser.go_cfg::<M>(inp, cfg)
@@ -91,14 +91,21 @@ where
     where
         I: 'a;
 
-    fn make_iter<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<Emit, Self::IterState<M>, E::Error> {
+    fn make_iter<M: Mode>(
+        &self,
+        inp: &mut InputRef<'a, '_, I, E>,
+    ) -> PResult<Emit, Self::IterState<M>, E::Error> {
         Ok((
             A::make_iter(&self.parser, inp)?,
             (self.cfg)(A::Config::default(), inp.ctx()),
         ))
     }
 
-    fn next<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>, state: &mut Self::IterState<M>) -> Option<PResult<M, O, E::Error>> {
+    fn next<M: Mode>(
+        &self,
+        inp: &mut InputRef<'a, '_, I, E>,
+        state: &mut Self::IterState<M>,
+    ) -> Option<PResult<M, O, E::Error>> {
         self.parser.next_cfg(inp, &mut state.0, &state.1)
     }
 }
@@ -613,7 +620,8 @@ impl<A: Clone, B: Clone, OA, I: ?Sized, E> Clone for ThenWithCtx<A, B, OA, I, E>
     }
 }
 
-impl<'a, I, E, A, B, OA, OB> Parser<'a, I, OB, E> for ThenWithCtx<A, B, OA, I, extra::Full<E::Error, E::State, OA>>
+impl<'a, I, E, A, B, OA, OB> Parser<'a, I, OB, E>
+    for ThenWithCtx<A, B, OA, I, extra::Full<E::Error, E::State, OA>>
 where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
@@ -623,10 +631,7 @@ where
 {
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, OB, E::Error> {
         let p1 = self.parser.go::<Emit>(inp)?;
-        inp.with_ctx(
-            p1,
-            |inp| self.then.go::<M>(inp)
-        )
+        inp.with_ctx(p1, |inp| self.then.go::<M>(inp))
     }
 
     go_extra!(OB);
@@ -656,9 +661,7 @@ where
     Ctx: 'a + Clone,
 {
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
-        inp.with_ctx(self.ctx.clone(), |inp| {
-            self.parser.go::<M>(inp)
-        })
+        inp.with_ctx(self.ctx.clone(), |inp| self.parser.go::<M>(inp))
     }
 
     go_extra!(O);
@@ -689,9 +692,7 @@ where
     Ctx: 'a,
 {
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
-        inp.with_ctx((self.mapper)(inp.ctx()), |inp| {
-            self.parser.go::<M>(inp)
-        })
+        inp.with_ctx((self.mapper)(inp.ctx()), |inp| self.parser.go::<M>(inp))
     }
 
     go_extra!(O);

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -8,6 +8,42 @@
 use super::*;
 use core::mem::MaybeUninit;
 
+/// Alter the configuration of a struct using parse-time context
+pub struct Configure<A, F> {
+    pub(crate) parser: A,
+    pub(crate) cfg: F,
+}
+
+impl<A: Copy, F: Copy> Copy for Configure<A, F> {}
+impl<A: Clone, F: Clone> Clone for Configure<A, F> {
+    fn clone(&self) -> Self {
+        Configure {
+            parser: self.parser.clone(),
+            cfg: self.cfg.clone(),
+        }
+    }
+}
+
+impl<'a, I, O, E, A, F> Parser<'a, I, O, E> for Configure<A, F>
+where
+    A: Parser<'a, I, O, E>,
+    F: Fn(A::Config, &E::Context) -> A::Config,
+    I: Input + ?Sized,
+    E: ParserExtra<'a, I>,
+{
+    type Config = ();
+
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error>
+        where
+            Self: Sized,
+    {
+        let cfg = (self.cfg)(A::Config::default(), inp.ctx());
+        self.parser.go_cfg::<M>(inp, cfg)
+    }
+
+    go_extra!(O);
+}
+
 /// See [`Parser::map_slice`].
 pub struct MapSlice<'a, A, I, O, E, F, U>
 where
@@ -56,6 +92,8 @@ where
     A: Parser<'a, I, O, E>,
     F: Fn(&'a I::Slice) -> U,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, U, E::Error> {
         let before = inp.save();
         self.parser.go::<Check>(inp)?;
@@ -89,6 +127,8 @@ where
     I: Input + SliceInput + ?Sized,
     E: ParserExtra<'a, I>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, &'a I::Slice, E::Error>
     where
         Self: Sized,
@@ -126,6 +166,8 @@ where
     A: Parser<'a, I, O, E>,
     F: Fn(&O) -> bool,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         let before = inp.save();
         self.parser.go::<Emit>(inp).and_then(|out| {
@@ -159,6 +201,8 @@ where
     A: Parser<'a, I, OA, E>,
     F: Fn(OA) -> O,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         self.parser
             .go::<M>(inp)
@@ -183,6 +227,8 @@ where
     A: Parser<'a, I, OA, E>,
     F: Fn(OA, I::Span) -> O,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         let before = inp.save();
         self.parser.go::<M>(inp).map(|out| {
@@ -211,6 +257,8 @@ where
     A: Parser<'a, I, OA, E>,
     F: Fn(OA, I::Span, &mut E::State) -> O,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         let before = inp.save();
         self.parser.go::<Emit>(inp).map(|out| {
@@ -240,6 +288,8 @@ where
     A: Parser<'a, I, OA, E>,
     F: Fn(OA, I::Span) -> Result<O, E::Error>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         let before = inp.save();
         self.parser.go::<Emit>(inp).and_then(|out| {
@@ -269,6 +319,8 @@ where
     A: Parser<'a, I, OA, E>,
     F: Fn(OA, I::Span, &mut E::State) -> Result<O, E::Error>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         let before = inp.save();
         self.parser.go::<Emit>(inp).and_then(|out| {
@@ -309,6 +361,8 @@ where
     A: Parser<'a, I, OA, E>,
     O: Clone,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         self.parser
             .go::<Check>(inp)
@@ -340,6 +394,8 @@ where
     E: ParserExtra<'a, I>,
     A: Parser<'a, I, OA, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, (), E::Error> {
         self.parser.go::<Check>(inp).map(|_| M::bind(|| ()))
     }
@@ -372,6 +428,8 @@ where
     A: Parser<'a, I, OA, E>,
     B: Parser<'a, I, OB, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, (OA, OB), E::Error> {
         let a = self.parser_a.go::<M>(inp)?;
         let b = self.parser_b.go::<M>(inp)?;
@@ -406,6 +464,8 @@ where
     A: Parser<'a, I, OA, E>,
     B: Parser<'a, I, OB, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, OB, E::Error> {
         let _a = self.parser_a.go::<Check>(inp)?;
         let b = self.parser_b.go::<M>(inp)?;
@@ -440,6 +500,8 @@ where
     A: Parser<'a, I, OA, E>,
     B: Parser<'a, I, OB, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, OA, E::Error> {
         let a = self.parser_a.go::<M>(inp)?;
         let _b = self.parser_b.go::<Check>(inp)?;
@@ -475,6 +537,8 @@ where
     B: Parser<'a, I, OB, E>,
     F: Fn(OA) -> B,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, OB, E::Error> {
         let before = inp.save();
         match self.parser.go::<Emit>(inp) {
@@ -500,6 +564,49 @@ where
     go_extra!(OB);
 }
 
+/// See [`Parser::then_with_ctx`].
+pub struct ThenWithCtx<A, B, OA, F, I: ?Sized, E> {
+    pub(crate) parser: A,
+    pub(crate) then: B,
+    pub(crate) make_ctx: F,
+    pub(crate) phantom: PhantomData<(B, OA, E, I)>,
+}
+
+impl<A: Copy, B: Copy, OA, F: Copy, I: ?Sized, E> Copy for ThenWithCtx<A, B, OA, F, I, E> {}
+impl<A: Clone, B: Clone, OA, F: Clone, I: ?Sized, E> Clone for ThenWithCtx<A, B, OA, F, I, E> {
+    fn clone(&self) -> Self {
+        Self {
+            parser: self.parser.clone(),
+            then: self.then.clone(),
+            make_ctx: self.make_ctx.clone(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, I, E, CtxN, A, B, OA, OB, F> Parser<'a, I, OB, E> for ThenWithCtx<A, B, OA, F, I, extra::Full<E::Error, E::State, CtxN>>
+where
+    I: Input + ?Sized,
+    E: ParserExtra<'a, I>,
+    A: Parser<'a, I, OA, E>,
+    B: Parser<'a, I, OB, extra::Full<E::Error, E::State, CtxN>>,
+    F: Fn(OA, &E::Context) -> CtxN,
+    CtxN: 'a,
+{
+    type Config = ();
+
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, OB, E::Error> {
+        let p1 = self.parser.go::<Emit>(inp)?;
+        let ctx = (self.make_ctx)(p1, inp.ctx());
+        inp.with_ctx(
+            ctx,
+            |inp| self.then.go::<M>(inp)
+        )
+    }
+
+    go_extra!(OB);
+}
+
 /// See [`Parser::delimited_by`].
 #[derive(Copy, Clone)]
 pub struct DelimitedBy<A, B, C, OB, OC> {
@@ -517,6 +624,8 @@ where
     B: Parser<'a, I, OB, E>,
     C: Parser<'a, I, OC, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, OA, E::Error> {
         let _ = self.start.go::<Check>(inp)?;
         let a = self.parser.go::<M>(inp)?;
@@ -542,6 +651,8 @@ where
     A: Parser<'a, I, OA, E>,
     B: Parser<'a, I, OB, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, OA, E::Error> {
         let _ = self.padding.go::<Check>(inp)?;
         let a = self.parser.go::<M>(inp)?;
@@ -566,6 +677,8 @@ where
     A: Parser<'a, I, O, E>,
     B: Parser<'a, I, O, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         let before = inp.save();
         match self.parser_a.go::<M>(inp) {
@@ -598,6 +711,8 @@ where
     A: Parser<'a, I, O, E>,
     F: Parser<'a, I, O, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         let before = inp.save();
         match self.parser.go::<M>(inp) {
@@ -616,6 +731,34 @@ where
     }
 
     go_extra!(O);
+}
+
+/// TODO
+#[derive(Default)]
+pub struct RepeatedCfg {
+    at_least: Option<usize>,
+    at_most: Option<usize>,
+}
+
+impl RepeatedCfg {
+    /// TODO
+    pub fn at_least(mut self, n: usize) -> Self {
+        self.at_least = Some(n);
+        self
+    }
+
+    /// TODO
+    pub fn at_most(mut self, n: usize) -> Self {
+        self.at_most = Some(n);
+        self
+    }
+
+    /// TODO
+    pub fn exactly(mut self, n: usize) -> Self {
+        self.at_least = Some(n);
+        self.at_most = Some(n);
+        self
+    }
 }
 
 /// See [`Parser::repeated`].
@@ -713,6 +856,8 @@ where
     E: ParserExtra<'a, I>,
     A: Parser<'a, I, OA, E>,
 {
+    type Config = RepeatedCfg;
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, (), E::Error> {
         let mut state = self.make_iter::<Check>(inp)?;
 
@@ -744,6 +889,7 @@ where
         Ok(0)
     }
 
+    // TODO: Support config
     fn next<M: Mode>(
         &self,
         inp: &mut InputRef<'a, '_, I, E>,
@@ -990,6 +1136,8 @@ where
     B: Parser<'a, I, OB, E>,
     C: Container<OA>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, C, E::Error> {
         // STEPS:
         // 1. If allow_leading -> Consume separator if there
@@ -1142,6 +1290,8 @@ where
     A: IterParser<'a, I, O, E>,
     C: Container<O>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, C, E::Error> {
         let mut output = M::bind::<C, _>(|| C::default());
         let mut iter_state = self.parser.make_iter::<M>(inp)?;
@@ -1174,6 +1324,8 @@ where
     E: ParserExtra<'a, I>,
     A: Parser<'a, I, O, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, Option<O>, E::Error> {
         let before = inp.save();
         Ok(match self.parser.go::<M>(inp) {
@@ -1201,6 +1353,8 @@ where
     E: ParserExtra<'a, I>,
     A: Parser<'a, I, OA, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, (), E::Error> {
         let before = inp.save();
 
@@ -1237,6 +1391,8 @@ where
     A: Parser<'a, I, OA, E>,
     B: Parser<'a, I, OB, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, OA, E::Error> {
         let before = inp.save();
         match self.parser_a.go::<M>(inp) {
@@ -1300,6 +1456,8 @@ where
     A: Parser<'a, I, OA, E>,
     C: ContainerExactly<OA, N>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, C, E::Error> {
         let mut i = 0;
         let mut output = M::bind(|| C::uninit());
@@ -1428,6 +1586,8 @@ where
     B: Parser<'a, I, OB, E>,
     C: ContainerExactly<OA, N>,
 {
+    type Config = ();
+
     // FIXME: why parse result output is not C ?
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, [OA; N], E::Error> {
         if self.allow_leading {
@@ -1511,6 +1671,8 @@ where
     A::IntoIter: DoubleEndedIterator,
     F: Fn(A::Item, B) -> B,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, B, E::Error>
     where
         Self: Sized,
@@ -1551,6 +1713,8 @@ where
     B: IntoIterator,
     F: Fn(A, B::Item) -> A,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, A, E::Error>
     where
         Self: Sized,
@@ -1577,6 +1741,8 @@ where
     E: ParserExtra<'a, I>,
     A: Parser<'a, I, O, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         let before = inp.save();
         match self.parser.go::<M>(inp) {
@@ -1605,6 +1771,8 @@ where
     A: Parser<'a, I, O, E>,
     F: Fn(E::Error) -> E::Error,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error>
     where
         Self: Sized,
@@ -1632,6 +1800,8 @@ where
     A: Parser<'a, I, O, E>,
     F: Fn(E::Error, I::Span) -> E::Error,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error>
     where
         Self: Sized,
@@ -1661,6 +1831,8 @@ where
     A: Parser<'a, I, O, E>,
     F: Fn(E::Error, I::Span, &mut E::State) -> E::Error,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error>
     where
         Self: Sized,
@@ -1701,6 +1873,8 @@ where
     A: Parser<'a, I, OA, E>,
     F: Fn(OA, I::Span, &mut Emitter<E::Error>) -> U,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, U, E::Error>
     where
         Self: Sized,
@@ -1734,6 +1908,8 @@ where
     A: Parser<'a, I, O, E>,
     F: Fn(E::Error) -> Result<O, E::Error>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error>
     where
         Self: Sized,

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -27,7 +27,7 @@ impl<A: Clone, F: Clone> Clone for Configure<A, F> {
 impl<'a, I, O, E, A, F> Parser<'a, I, O, E> for Configure<A, F>
 where
     A: Parser<'a, I, O, E>,
-    F: Fn(&mut A::Config, &E::Context),
+    F: Fn(A::Config, &E::Context) -> A::Config,
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
@@ -37,8 +37,7 @@ where
         where
             Self: Sized,
     {
-        let mut cfg = A::Config::default();
-        (self.cfg)(&mut cfg, inp.ctx());
+        let cfg = (self.cfg)(A::Config::default(), inp.ctx());
         self.parser.go_cfg::<M>(inp, cfg)
     }
 

--- a/src/zero_copy/combinator.rs
+++ b/src/zero_copy/combinator.rs
@@ -27,7 +27,7 @@ impl<A: Clone, F: Clone> Clone for Configure<A, F> {
 impl<'a, I, O, E, A, F> Parser<'a, I, O, E> for Configure<A, F>
 where
     A: Parser<'a, I, O, E>,
-    F: Fn(A::Config, &E::Context) -> A::Config,
+    F: Fn(&mut A::Config, &E::Context),
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
@@ -37,7 +37,8 @@ where
         where
             Self: Sized,
     {
-        let cfg = (self.cfg)(A::Config::default(), inp.ctx());
+        let mut cfg = A::Config::default();
+        (self.cfg)(&mut cfg, inp.ctx());
         self.parser.go_cfg::<M>(inp, cfg)
     }
 
@@ -565,46 +566,111 @@ where
 }
 
 /// See [`Parser::then_with_ctx`].
-pub struct ThenWithCtx<A, B, OA, F, I: ?Sized, E> {
+pub struct ThenWithCtx<A, B, OA, I: ?Sized, E> {
     pub(crate) parser: A,
     pub(crate) then: B,
-    pub(crate) make_ctx: F,
     pub(crate) phantom: PhantomData<(B, OA, E, I)>,
 }
 
-impl<A: Copy, B: Copy, OA, F: Copy, I: ?Sized, E> Copy for ThenWithCtx<A, B, OA, F, I, E> {}
-impl<A: Clone, B: Clone, OA, F: Clone, I: ?Sized, E> Clone for ThenWithCtx<A, B, OA, F, I, E> {
+impl<A: Copy, B: Copy, OA, I: ?Sized, E> Copy for ThenWithCtx<A, B, OA, I, E> {}
+impl<A: Clone, B: Clone, OA, I: ?Sized, E> Clone for ThenWithCtx<A, B, OA, I, E> {
     fn clone(&self) -> Self {
         Self {
             parser: self.parser.clone(),
             then: self.then.clone(),
-            make_ctx: self.make_ctx.clone(),
             phantom: PhantomData,
         }
     }
 }
 
-impl<'a, I, E, CtxN, A, B, OA, OB, F> Parser<'a, I, OB, E> for ThenWithCtx<A, B, OA, F, I, extra::Full<E::Error, E::State, CtxN>>
+impl<'a, I, E, A, B, OA, OB> Parser<'a, I, OB, E> for ThenWithCtx<A, B, OA, I, extra::Full<E::Error, E::State, OA>>
 where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
     A: Parser<'a, I, OA, E>,
-    B: Parser<'a, I, OB, extra::Full<E::Error, E::State, CtxN>>,
-    F: Fn(OA, &E::Context) -> CtxN,
-    CtxN: 'a,
+    B: Parser<'a, I, OB, extra::Full<E::Error, E::State, OA>>,
+    OA: 'a,
 {
     type Config = ();
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, OB, E::Error> {
         let p1 = self.parser.go::<Emit>(inp)?;
-        let ctx = (self.make_ctx)(p1, inp.ctx());
         inp.with_ctx(
-            ctx,
+            p1,
             |inp| self.then.go::<M>(inp)
         )
     }
 
     go_extra!(OB);
+}
+
+/// See [`Parser::with_ctx`].
+pub struct WithCtx<A, Ctx> {
+    pub(crate) parser: A,
+    pub(crate) ctx: Ctx,
+}
+
+impl<A: Copy, Ctx: Copy> Copy for WithCtx<A, Ctx> {}
+impl<A: Clone, Ctx: Clone> Clone for WithCtx<A, Ctx> {
+    fn clone(&self) -> Self {
+        WithCtx {
+            parser: self.parser.clone(),
+            ctx: self.ctx.clone(),
+        }
+    }
+}
+
+impl<'a, I, O, E, A, Ctx> Parser<'a, I, O, E> for WithCtx<A, Ctx>
+where
+    I: Input + ?Sized,
+    E: ParserExtra<'a, I>,
+    A: Parser<'a, I, O, extra::Full<E::Error, E::State, Ctx>>,
+    Ctx: 'a + Clone,
+{
+    type Config = ();
+
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
+        inp.with_ctx(self.ctx.clone(), |inp| {
+            self.parser.go::<M>(inp)
+        })
+    }
+
+    go_extra!(O);
+}
+
+/// See [`Parser::map_ctx`].
+pub struct MapCtx<A, F> {
+    pub(crate) parser: A,
+    pub(crate) mapper: F,
+}
+
+impl<A: Copy, F: Copy> Copy for MapCtx<A, F> {}
+impl<A: Clone, F: Clone> Clone for MapCtx<A, F> {
+    fn clone(&self) -> Self {
+        MapCtx {
+            parser: self.parser.clone(),
+            mapper: self.mapper.clone(),
+        }
+    }
+}
+
+impl<'a, I, O, E, A, F, Ctx> Parser<'a, I, O, E> for MapCtx<A, F>
+where
+    I: Input + ?Sized,
+    E: ParserExtra<'a, I>,
+    A: Parser<'a, I, O, extra::Full<E::Error, E::State, Ctx>>,
+    F: Fn(&E::Context) -> Ctx,
+    Ctx: 'a,
+{
+    type Config = ();
+
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
+        inp.with_ctx((self.mapper)(inp.ctx()), |inp| {
+            self.parser.go::<M>(inp)
+        })
+    }
+
+    go_extra!(O);
 }
 
 /// See [`Parser::delimited_by`].

--- a/src/zero_copy/extra.rs
+++ b/src/zero_copy/extra.rs
@@ -6,13 +6,14 @@ mod internal {
     use super::*;
 
     pub trait ExtraSealed {}
-    impl<E, S> ExtraSealed for Full<E, S> {}
+    impl<E, S, C> ExtraSealed for Full<E, S, C> {}
 }
 
 use internal::ExtraSealed;
 
 type DefaultErr = EmptyErr;
 type DefaultState = ();
+type DefaultCtx = ();
 
 /// Sealed trait for parser extra information - error type, state type, etc.
 pub trait ParserExtra<'a, I>: 'a + ExtraSealed
@@ -23,26 +24,33 @@ where
     type Error: Error<I> + 'a;
     /// State type to use for the parser
     type State: 'a;
+    /// Context used for parser configuration
+    type Context: 'a;
 }
 
 /// Use all default extra types
-pub type Default = Full<DefaultErr, DefaultState>;
+pub type Default = Full<DefaultErr, DefaultState, DefaultCtx>;
 
 /// Use specified error type, but default other types
-pub type Err<E> = Full<E, DefaultState>;
+pub type Err<E> = Full<E, DefaultState, DefaultCtx>;
 
 /// Use specified state type, but default other types
-pub type State<S> = Full<DefaultErr, S>;
+pub type State<S> = Full<DefaultErr, S, DefaultCtx>;
+
+/// Use specified context type, but default other types
+pub type Context<C> = Full<DefaultErr, DefaultState, C>;
 
 /// Specify all extra types
-pub struct Full<E, S>(PhantomData<(E, S)>);
+pub struct Full<E, S, C>(PhantomData<(E, S, C)>);
 
-impl<'a, I, E, S> ParserExtra<'a, I> for Full<E, S>
+impl<'a, I, E, S, C> ParserExtra<'a, I> for Full<E, S, C>
 where
     I: ?Sized + Input,
     E: Error<I> + 'a,
     S: 'a,
+    C: 'a,
 {
     type Error = E;
     type State = S;
+    type Context = C;
 }

--- a/src/zero_copy/input.rs
+++ b/src/zero_copy/input.rs
@@ -182,11 +182,15 @@ pub struct InputRef<'a, 'parse, I: Input + ?Sized, E: ParserExtra<'a, I>> {
     marker: Marker<I>,
     // TODO: Don't use a result, use something like `Cow` but that allows `E::State` to not be `Clone`
     state: Result<&'parse mut E::State, E::State>,
+    ctx: E::Context,
     errors: Vec<E::Error>,
 }
 
 impl<'a, 'parse, I: Input + ?Sized, E: ParserExtra<'a, I>> InputRef<'a, 'parse, I, E> {
-    pub(crate) fn new(input: &'a I, state: Result<&'parse mut E::State, E::State>) -> Self {
+    pub(crate) fn new(input: &'a I, state: Result<&'parse mut E::State, E::State>) -> Self
+    where
+        E::Context: Default,
+    {
         Self {
             input,
             marker: Marker {
@@ -195,8 +199,33 @@ impl<'a, 'parse, I: Input + ?Sized, E: ParserExtra<'a, I>> InputRef<'a, 'parse, 
                 err_count: 0,
             },
             state,
+            ctx: E::Context::default(),
             errors: Vec::new(),
         }
+    }
+
+    pub(crate) fn with_ctx<'sub_parse, CtxN, O>(
+        &'sub_parse mut self,
+        new_ctx: CtxN,
+        f: impl FnOnce(&mut InputRef<'a, 'sub_parse, I, extra::Full<E::Error, E::State, CtxN>>) -> O,
+    ) -> O
+    where
+        'parse: 'sub_parse,
+        CtxN: 'a,
+    {
+        use core::mem;
+
+        let mut new_ctx = InputRef {
+            input: self.input,
+            marker: self.marker,
+            state: self.state,
+            ctx: new_ctx,
+            errors: mem::take(&mut self.errors),
+        };
+        let res = f(&mut new_ctx);
+        self.marker = new_ctx.marker;
+        self.errors = mem::take(&mut new_ctx.errors);
+        res
     }
 
     /// Save off a [`Marker`] to the current position in the input
@@ -215,6 +244,10 @@ impl<'a, 'parse, I: Input + ?Sized, E: ParserExtra<'a, I>> InputRef<'a, 'parse, 
             Ok(state) => *state,
             Err(state) => state,
         }
+    }
+
+    pub(crate) fn ctx(&self) -> &E::Context {
+        &self.ctx
     }
 
     pub(crate) fn skip_while<F: FnMut(&I::Token) -> bool>(&mut self, mut f: F) {

--- a/src/zero_copy/input.rs
+++ b/src/zero_copy/input.rs
@@ -218,7 +218,10 @@ impl<'a, 'parse, I: Input + ?Sized, E: ParserExtra<'a, I>> InputRef<'a, 'parse, 
         let mut new_ctx = InputRef {
             input: self.input,
             marker: self.marker,
-            state: self.state,
+            state: match &mut self.state {
+                Ok(state) => Ok(*state),
+                Err(state) => Ok(state),
+            },
             ctx: new_ctx,
             errors: mem::take(&mut self.errors),
         };

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -493,7 +493,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I> = extra::Defaul
     fn configure<F>(self, cfg: F) -> Configure<Self, F>
     where
         Self: Sized,
-        F: Fn(&mut Self::Config, &E::Context),
+        F: Fn(Self::Config, &E::Context) -> Self::Config,
     {
         Configure {
             parser: self,

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -16,10 +16,18 @@ macro_rules! go_extra {
 
 macro_rules! go_cfg_extra {
     ( $O :ty ) => {
-        fn go_emit_cfg(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<Emit, $O, E::Error> {
+        fn go_emit_cfg(
+            &self,
+            inp: &mut InputRef<'a, '_, I, E>,
+            cfg: Self::Config,
+        ) -> PResult<Emit, $O, E::Error> {
             ConfigParser::<I, $O, E>::go_cfg::<Emit>(self, inp, cfg)
         }
-        fn go_check_cfg(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<Check, $O, E::Error> {
+        fn go_check_cfg(
+            &self,
+            inp: &mut InputRef<'a, '_, I, E>,
+            cfg: Self::Config,
+        ) -> PResult<Check, $O, E::Error> {
             ConfigParser::<I, $O, E>::go_cfg::<Check>(self, inp, cfg)
         }
     };
@@ -53,11 +61,11 @@ pub mod prelude {
         span::{SimpleSpan, Span as _},
         text,
         Boxed,
-        IterParser,
         ConfigIterParser,
+        ConfigParser,
+        IterParser,
         ParseResult,
         Parser,
-        ConfigParser,
     };
 }
 
@@ -300,7 +308,8 @@ mod internal {
 
         #[inline(always)]
         fn invoke_cfg<'a, I, O, E, P>(
-            parser: &P, inp: &mut InputRef<'a, '_, I, E>,
+            parser: &P,
+            inp: &mut InputRef<'a, '_, I, E>,
             cfg: P::Config,
         ) -> PResult<Self, O, E::Error>
         where
@@ -348,7 +357,7 @@ mod internal {
         fn invoke_cfg<'a, I, O, E, P>(
             parser: &P,
             inp: &mut InputRef<'a, '_, I, E>,
-            cfg: P::Config
+            cfg: P::Config,
         ) -> PResult<Self, O, E::Error>
         where
             I: Input + ?Sized,
@@ -932,7 +941,6 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I> = extra::Defaul
         Self: Sized,
         CtxN: 'a,
         P: Parser<'a, I, U, extra::Full<E::Error, E::State, CtxN>>,
-
     {
         ThenWithCtx {
             parser: self,
@@ -942,10 +950,7 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I> = extra::Defaul
     }
 
     /// TODO
-    fn map_ctx<Ctx, F>(
-        self,
-        mapper: F,
-    ) -> MapCtx<Self, F>
+    fn map_ctx<Ctx, F>(self, mapper: F) -> MapCtx<Self, F>
     where
         Self: Sized,
         F: Fn(O, &E::Context) -> Ctx,
@@ -958,18 +963,12 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I> = extra::Defaul
     }
 
     /// TODO
-    fn with_ctx<Ctx>(
-        self,
-        ctx: Ctx,
-    ) -> WithCtx<Self, Ctx>
+    fn with_ctx<Ctx>(self, ctx: Ctx) -> WithCtx<Self, Ctx>
     where
         Self: Sized,
         Ctx: 'a + Clone,
     {
-        WithCtx {
-            parser: self,
-            ctx,
-        }
+        WithCtx { parser: self, ctx }
     }
 
     /// ```
@@ -1749,14 +1748,26 @@ where
 
     /// Parse a stream with the provided configured values. This can be used to control a parser's
     /// behavior at parse-time.
-    fn go_cfg<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<M, O, E::Error>
+    fn go_cfg<M: Mode>(
+        &self,
+        inp: &mut InputRef<'a, '_, I, E>,
+        cfg: Self::Config,
+    ) -> PResult<M, O, E::Error>
     where
         Self: Sized;
 
     #[doc(hidden)]
-    fn go_emit_cfg(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<Emit, O, E::Error>;
+    fn go_emit_cfg(
+        &self,
+        inp: &mut InputRef<'a, '_, I, E>,
+        cfg: Self::Config,
+    ) -> PResult<Emit, O, E::Error>;
     #[doc(hidden)]
-    fn go_check_cfg(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<Check, O, E::Error>;
+    fn go_check_cfg(
+        &self,
+        inp: &mut InputRef<'a, '_, I, E>,
+        cfg: Self::Config,
+    ) -> PResult<Check, O, E::Error>;
 
     /// A combinator that allows configuration of the parser from the current context
     fn configure<F>(self, cfg: F) -> Configure<Self, F>
@@ -1764,10 +1775,7 @@ where
         Self: Sized,
         F: Fn(Self::Config, &E::Context) -> Self::Config,
     {
-        Configure {
-            parser: self,
-            cfg,
-        }
+        Configure { parser: self, cfg }
     }
 }
 
@@ -1943,7 +1951,9 @@ where
 
 /// An iterable equivalent of [`ConfigParser`], i.e: a parser that generates a sequence of outputs and
 /// can be configured at runtime.
-pub trait ConfigIterParser<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I> = extra::Default>: IterParser<'a, I, O, E> {
+pub trait ConfigIterParser<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I> = extra::Default>:
+    IterParser<'a, I, O, E>
+{
     /// Type used to configure the parser
     type Config: Default;
 

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -87,23 +87,23 @@ where
 }
 
 /// See [`empty`].
-pub struct Empty<I: ?Sized>(PhantomData<I>);
+pub struct Empty<I: ?Sized, E>(PhantomData<(E, I)>);
 
 /// A parser that parses no inputs.
 ///
 /// The output type of this parser is `()`.
-pub const fn empty<I: Input + ?Sized>() -> Empty<I> {
+pub const fn empty<I: Input + ?Sized, E>() -> Empty<I, E> {
     Empty(PhantomData)
 }
 
-impl<I: ?Sized> Copy for Empty<I> {}
-impl<I: ?Sized> Clone for Empty<I> {
+impl<I: ?Sized, E> Copy for Empty<I, E> {}
+impl<I: ?Sized, E> Clone for Empty<I, E> {
     fn clone(&self) -> Self {
         Empty(PhantomData)
     }
 }
 
-impl<'a, I, E> Parser<'a, I, (), E> for Empty<I>
+impl<'a, I, E> Parser<'a, I, (), E> for Empty<I, E>
 where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
@@ -129,7 +129,7 @@ pub struct JustCfg<T> {
 
 impl<T> JustCfg<T> {
     /// TODO
-    pub fn set_seq(mut self, new_seq: T) -> Self {
+    pub fn seq(mut self, new_seq: T) -> Self {
         self.seq = Some(new_seq);
         self
     }

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -70,6 +70,8 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, (), E::Error> {
         let before = inp.save();
         match inp.next() {
@@ -106,6 +108,8 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, _: &mut InputRef<'a, '_, I, E>) -> PResult<M, (), E::Error> {
         Ok(M::bind(|| ()))
     }
@@ -117,6 +121,25 @@ where
 //     type Iter<'a> = C::Iter<'a>;
 //     fn iter(&self) -> Self::Iter<'_> { (*self).iter() }
 // }
+
+/// TODO
+pub struct JustCfg<T> {
+    seq: Option<T>,
+}
+
+impl<T> JustCfg<T> {
+    /// TODO
+    pub fn set_seq(mut self, new_seq: T) -> Self {
+        self.seq = Some(new_seq);
+        self
+    }
+}
+
+impl<T> Default for JustCfg<T> {
+    fn default() -> Self {
+        JustCfg { seq: None }
+    }
+}
 
 /// See [`just`].
 pub struct Just<T, I: ?Sized, E = EmptyErr> {
@@ -171,8 +194,17 @@ where
     I::Token: Clone + PartialEq,
     T: OrderedSeq<I::Token> + Clone,
 {
+    type Config = JustCfg<T>;
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, T, E::Error> {
-        let mut items = self.seq.seq_iter();
+        Self::go_cfg::<M>(self, inp, JustCfg::default())
+    }
+
+    fn go_cfg<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<M, T, E::Error> {
+        let seq = cfg.seq.as_ref()
+            .unwrap_or(&self.seq);
+
+        let mut items = seq.seq_iter();
         loop {
             match items.next() {
                 Some(next) => {
@@ -192,7 +224,7 @@ where
                         }
                     }
                 }
-                None => break Ok(M::bind(|| self.seq.clone())),
+                None => break Ok(M::bind(|| seq.clone())),
             }
         }
     }
@@ -253,6 +285,8 @@ where
     I::Token: Clone + PartialEq,
     T: Seq<I::Token>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, I::Token, E::Error> {
         let before = inp.save();
         match inp.next() {
@@ -324,6 +358,8 @@ where
     I::Token: PartialEq,
     T: Seq<I::Token>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, I::Token, E::Error> {
         let before = inp.save();
         match inp.next() {
@@ -357,6 +393,8 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, I::Token, E::Error> {
         let before = inp.save();
         match inp.next() {
@@ -484,6 +522,8 @@ where
     P: Parser<'a, I, OP, E>,
     C: Container<I::Token>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, (C, OP), E::Error> {
         let mut output = M::bind(|| C::default());
 
@@ -555,6 +595,8 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, _inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         todo!("Attempted to use an unimplemented parser")
     }
@@ -644,6 +686,8 @@ macro_rules! impl_choice_for_tuple {
             E: ParserExtra<'a, I>,
             $($X: Parser<'a, I, O, E>),*
         {
+            type Config = ();
+
             fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
                 let before = inp.save();
 
@@ -731,6 +775,8 @@ macro_rules! impl_group_for_tuple {
             E: ParserExtra<'a, I>,
             $($X: Parser<'a, I, $O, E>),*
         {
+            type Config = ();
+
             fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, ($($O,)*), E::Error> {
                 let Group { parsers: ($($X,)*) } = self;
 

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -206,9 +206,12 @@ where
 {
     type Config = JustCfg<T>;
 
-    fn go_cfg<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<M, T, E::Error> {
-        let seq = cfg.seq.as_ref()
-            .unwrap_or(&self.seq);
+    fn go_cfg<M: Mode>(
+        &self,
+        inp: &mut InputRef<'a, '_, I, E>,
+        cfg: Self::Config,
+    ) -> PResult<M, T, E::Error> {
+        let seq = cfg.seq.as_ref().unwrap_or(&self.seq);
 
         let mut items = seq.seq_iter();
         loop {

--- a/src/zero_copy/primitive.rs
+++ b/src/zero_copy/primitive.rs
@@ -70,8 +70,6 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
-    type Config = ();
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, (), E::Error> {
         let before = inp.save();
         match inp.next() {
@@ -108,8 +106,6 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
-    type Config = ();
-
     fn go<M: Mode>(&self, _: &mut InputRef<'a, '_, I, E>) -> PResult<M, (), E::Error> {
         Ok(M::bind(|| ()))
     }
@@ -194,11 +190,21 @@ where
     I::Token: Clone + PartialEq,
     T: OrderedSeq<I::Token> + Clone,
 {
-    type Config = JustCfg<T>;
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, T, E::Error> {
         Self::go_cfg::<M>(self, inp, JustCfg::default())
     }
+
+    go_extra!(T);
+}
+
+impl<'a, I, E, T> ConfigParser<'a, I, T, E> for Just<T, I, E>
+where
+    I: Input + ?Sized,
+    E: ParserExtra<'a, I>,
+    I::Token: Clone + PartialEq,
+    T: OrderedSeq<I::Token> + Clone,
+{
+    type Config = JustCfg<T>;
 
     fn go_cfg<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<M, T, E::Error> {
         let seq = cfg.seq.as_ref()
@@ -229,7 +235,7 @@ where
         }
     }
 
-    go_extra!(T);
+    go_cfg_extra!(T);
 }
 
 /// See [`one_of`].
@@ -285,8 +291,6 @@ where
     I::Token: Clone + PartialEq,
     T: Seq<I::Token>,
 {
-    type Config = ();
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, I::Token, E::Error> {
         let before = inp.save();
         match inp.next() {
@@ -358,8 +362,6 @@ where
     I::Token: PartialEq,
     T: Seq<I::Token>,
 {
-    type Config = ();
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, I::Token, E::Error> {
         let before = inp.save();
         match inp.next() {
@@ -393,8 +395,6 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
-    type Config = ();
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, I::Token, E::Error> {
         let before = inp.save();
         match inp.next() {
@@ -522,8 +522,6 @@ where
     P: Parser<'a, I, OP, E>,
     C: Container<I::Token>,
 {
-    type Config = ();
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, (C, OP), E::Error> {
         let mut output = M::bind(|| C::default());
 
@@ -595,8 +593,6 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
-    type Config = ();
-
     fn go<M: Mode>(&self, _inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         todo!("Attempted to use an unimplemented parser")
     }
@@ -686,8 +682,6 @@ macro_rules! impl_choice_for_tuple {
             E: ParserExtra<'a, I>,
             $($X: Parser<'a, I, O, E>),*
         {
-            type Config = ();
-
             fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
                 let before = inp.save();
 
@@ -775,8 +769,6 @@ macro_rules! impl_group_for_tuple {
             E: ParserExtra<'a, I>,
             $($X: Parser<'a, I, $O, E>),*
         {
-            type Config = ();
-
             fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, ($($O,)*), E::Error> {
                 let Group { parsers: ($($X,)*) } = self;
 

--- a/src/zero_copy/recursive.rs
+++ b/src/zero_copy/recursive.rs
@@ -163,7 +163,6 @@ where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
 {
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         M::invoke(&*self.parser(), inp)
     }

--- a/src/zero_copy/recursive.rs
+++ b/src/zero_copy/recursive.rs
@@ -45,12 +45,12 @@ enum RecursiveInner<T: ?Sized> {
 
 /// Type for recursive parsers that are defined through a call to `recursive`, and as such
 /// need no internal indirection
-pub type Direct<'a, I, O, Extra, Cfg> = dyn Parser<'a, I, O, Extra, Config = Cfg> + 'a;
+pub type Direct<'a, I, O, Extra> = dyn Parser<'a, I, O, Extra> + 'a;
 
 /// Type for recursive parsers that are defined through a call to [`Recursive::declare`], and as
 /// such require an additional layer of allocation.
-pub struct Indirect<'a, I: Input + ?Sized, O, Extra: ParserExtra<'a, I>, Cfg> {
-    inner: OnceCell<Box<dyn Parser<'a, I, O, Extra, Config = Cfg> + 'a>>,
+pub struct Indirect<'a, I: Input + ?Sized, O, Extra: ParserExtra<'a, I>> {
+    inner: OnceCell<Box<dyn Parser<'a, I, O, Extra> + 'a>>,
 }
 
 /// A parser that can be defined in terms of itself by separating its [declaration](Recursive::declare) from its
@@ -61,7 +61,7 @@ pub struct Recursive<P: ?Sized> {
     inner: RecursiveInner<P>,
 }
 
-impl<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I>, Cfg> Recursive<Indirect<'a, I, O, E, Cfg>> {
+impl<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I>> Recursive<Indirect<'a, I, O, E>> {
     /// Declare the existence of a recursive parser, allowing it to be used to construct parser combinators before
     /// being fulled defined.
     ///
@@ -109,7 +109,7 @@ impl<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I>, Cfg> Recursive<Indirect<'a
     }
 
     /// Defines the parser after declaring it, allowing it to be used for parsing.
-    pub fn define<P: Parser<'a, I, O, E, Config = Cfg> + 'a>(&mut self, parser: P) {
+    pub fn define<P: Parser<'a, I, O, E> + 'a>(&mut self, parser: P) {
         self.parser()
             .inner
             .set(Box::new(parser))
@@ -139,14 +139,11 @@ impl<P: ?Sized> Clone for Recursive<P> {
     }
 }
 
-impl<'a, I, O, E, Cfg> Parser<'a, I, O, E> for Recursive<Indirect<'a, I, O, E, Cfg>>
+impl<'a, I, O, E> Parser<'a, I, O, E> for Recursive<Indirect<'a, I, O, E>>
 where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
-    Cfg: Default,
 {
-    type Config = Cfg;
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         M::invoke(
             self.parser()
@@ -158,35 +155,17 @@ where
         )
     }
 
-    fn go_cfg<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<M, O, E::Error> {
-        M::invoke_cfg(
-            self.parser()
-                .inner
-                .get()
-                .expect("Recursive parser used before being defined")
-                .as_ref(),
-            inp,
-            cfg,
-        )
-    }
-
     go_extra!(O);
 }
 
-impl<'a, I, O, E, Cfg> Parser<'a, I, O, E> for Recursive<Direct<'a, I, O, E, Cfg>>
+impl<'a, I, O, E> Parser<'a, I, O, E> for Recursive<Direct<'a, I, O, E>>
 where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
-    Cfg: Default,
 {
-    type Config = Cfg;
 
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         M::invoke(&*self.parser(), inp)
-    }
-
-    fn go_cfg<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>, cfg: Self::Config) -> PResult<M, O, E::Error> {
-        M::invoke_cfg(&*self.parser(), inp, cfg)
     }
 
     go_extra!(O);
@@ -241,15 +220,15 @@ where
 ///     ]),
 /// ])));
 /// ```
-pub fn recursive<'a, I, O, E, A, F>(f: F) -> Recursive<Direct<'a, I, O, E, A::Config>>
+pub fn recursive<'a, I, O, E, A, F>(f: F) -> Recursive<Direct<'a, I, O, E>>
 where
     I: Input + ?Sized,
     E: ParserExtra<'a, I>,
     A: Parser<'a, I, O, E> + 'a,
-    F: FnOnce(Recursive<Direct<'a, I, O, E, A::Config>>) -> A,
+    F: FnOnce(Recursive<Direct<'a, I, O, E>>) -> A,
 {
     let rc = Rc::new_cyclic(|rc| {
-        let rc: Weak<dyn Parser<'a, I, O, E, Config = A::Config>> = rc.clone() as _;
+        let rc: Weak<dyn Parser<'a, I, O, E>> = rc.clone() as _;
         let parser = Recursive {
             inner: RecursiveInner::Unowned(rc.clone()),
         };

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -143,8 +143,6 @@ where
     I::Token: Char,
     A: Parser<'a, I, O, E>,
 {
-    type Config = ();
-
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         inp.skip_while(|c| c.is_whitespace());
         let out = self.parser.go::<M>(inp)?;

--- a/src/zero_copy/text.rs
+++ b/src/zero_copy/text.rs
@@ -143,6 +143,8 @@ where
     I::Token: Char,
     A: Parser<'a, I, O, E>,
 {
+    type Config = ();
+
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O, E::Error> {
         inp.skip_while(|c| c.is_whitespace());
         let out = self.parser.go::<M>(inp)?;


### PR DESCRIPTION
Now with a more readable diff and less intrusive changes, thanks to `ParserExtra`

Only two configurations are provided so far - more may be added on-demand, but these two provide enough for useful examples and the most common use-case.