### PR TITLE
`zero-copy`: Add pratt parsing

### DIFF
--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -43,6 +43,7 @@ pub mod container;
 pub mod error;
 pub mod extra;
 pub mod input;
+pub mod pratt;
 pub mod primitive;
 pub mod recovery;
 pub mod recursive;
@@ -59,6 +60,7 @@ pub mod prelude {
     pub use super::{
         error::{EmptyErr, Error as _, Rich, Simple},
         extra,
+        pratt,
         primitive::{
             any, choice, empty, end, group, just, map_ctx, none_of, one_of, take_until, todo,
         },

--- a/src/zero_copy/mod.rs
+++ b/src/zero_copy/mod.rs
@@ -103,6 +103,7 @@ use self::{
     error::Error,
     extra::ParserExtra,
     input::{Input, InputRef, SliceInput, StrInput},
+    pratt::Pratt,
     prelude::*,
     recovery::RecoverWith,
     span::Span,
@@ -1747,6 +1748,110 @@ pub trait Parser<'a, I: Input + ?Sized, O, E: ParserExtra<'a, I> = extra::Defaul
     {
         Boxed {
             inner: Rc::new(self),
+        }
+    }
+
+    /// Use Pratt parsing to efficiently parse binary operators
+    /// with different associativity.
+    ///
+    /// The parsing algorithm currently uses recursion
+    /// to parse nested expressions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chumsky::zero_copy::prelude::*;
+    /// use chumsky::zero_copy::pratt::{InfixOperator, InfixPrecedence, Associativity};
+    ///
+    /// #[derive(Clone, Copy, Debug)]
+    /// enum Operator {
+    ///     Add,
+    ///     Sub,
+    ///     Mul,
+    ///     Div,
+    /// }
+    ///
+    /// enum Expr {
+    ///     Literal(i64),
+    ///     Add(Box<Expr>, Box<Expr>),
+    ///     Sub(Box<Expr>, Box<Expr>),
+    ///     Mul(Box<Expr>, Box<Expr>),
+    ///     Div(Box<Expr>, Box<Expr>),
+    /// }
+    ///
+    /// impl std::fmt::Display for Expr {
+    ///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    ///         match self {
+    ///             Self::Literal(literal) => write!(f, "{literal}"),
+    ///             Self::Add(left, right) => write!(f, "({left} + {right})"),
+    ///             Self::Sub(left, right) => write!(f, "({left} - {right})"),
+    ///             Self::Mul(left, right) => write!(f, "({left} * {right})"),
+    ///             Self::Div(left, right) => write!(f, "({left} / {right})"),
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// impl InfixOperator<Expr> for Operator {
+    ///     type Strength = u8;
+    ///
+    ///     fn precedence(&self) -> InfixPrecedence<Self::Strength> {
+    ///         // NOTE: Usually, in Rust for example, all these operators
+    ///         // are left-associative. However, in this example we define
+    ///         // then with different associativities for demonstration purposes.
+    ///         // (Although it doesn't really matter here since these operations
+    ///         // are commutative for integers anyway.)
+    ///         match self {
+    ///             Self::Add => InfixPrecedence::new(0, Associativity::Left),
+    ///             Self::Sub => InfixPrecedence::new(0, Associativity::Left),
+    ///             Self::Mul => InfixPrecedence::new(1, Associativity::Right),
+    ///             Self::Div => InfixPrecedence::new(1, Associativity::Right),
+    ///         }
+    ///     }
+    ///
+    ///     fn build_expression(self, left: Expr, right: Expr) -> Expr {
+    ///         let (left, right) = (Box::new(left), Box::new(right));
+    ///         match self {
+    ///             Self::Add => Expr::Add(left, right),
+    ///             Self::Sub => Expr::Sub(left, right),
+    ///             Self::Mul => Expr::Mul(left, right),
+    ///             Self::Div => Expr::Div(left, right),
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// let atom = text::int::<_, _, extra::Default>(10)
+    ///     .from_str()
+    ///     .unwrapped()
+    ///     .map(Expr::Literal);
+    ///
+    /// let operator = choice((
+    ///     just('+').to(Operator::Add),
+    ///     just('-').to(Operator::Sub),
+    ///     just('*').to(Operator::Mul),
+    ///     just('/').to(Operator::Div),
+    /// ));
+    ///
+    /// let expr = atom.pratt(operator.padded_by(just(' ')));
+    /// let expr_str = expr.map(|expr| expr.to_string()).then_ignore(end());
+    /// assert_eq!(expr_str.parse("1 + 2").into_result(), Ok("(1 + 2)".to_string()));
+    /// // `*` binds more strongly than `+`
+    /// assert_eq!(expr_str.parse("1 * 2 + 3").into_result(), Ok("((1 * 2) + 3)".to_string()));
+    /// assert_eq!(expr_str.parse("1 + 2 * 3").into_result(), Ok("(1 + (2 * 3))".to_string()));
+    /// // `+` is left-associative
+    /// assert_eq!(expr_str.parse("1 + 2 + 3").into_result(), Ok("((1 + 2) + 3)".to_string()));
+    /// // `*` is right-associative (in this example)
+    /// assert_eq!(expr_str.parse("1 * 2 * 3").into_result(), Ok("(1 * (2 * 3))".to_string()));
+    /// ```
+    fn pratt<OpParser, Op>(self, op_parser: OpParser) -> Pratt<E, Self, O, OpParser, Op>
+    where
+        Self: Sized,
+        OpParser: Parser<'a, I, Op, E>,
+        Op: pratt::InfixOperator<O>,
+    {
+        Pratt {
+            parser_atom: self,
+            parser_op: op_parser,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/zero_copy/pratt.rs
+++ b/src/zero_copy/pratt.rs
@@ -1,0 +1,472 @@
+//! Pratt parser for binary infix operators.
+//!
+//! Pratt parsing is an algorithm that allows efficient
+//! parsing of binary infix operators.
+//!
+//! The [`pratt()`] function creates a Pratt parser.
+//! Its documentation contains an example of how it can be used.
+
+use super::*;
+
+use core::cmp;
+
+/// Indicates which argument binds more strongly with a binary infix operator.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Associativity {
+    /// The operator binds more strongly with the argument to the left.
+    ///
+    /// For example `a + b + c` is parsed as `(a + b) + c`.
+    Left,
+
+    /// The operator binds more strongly with the argument to the right.
+    ///
+    /// For example `a + b + c` is parsed as `a + (b + c)`.
+    Right,
+}
+
+/// Indicates the binding strength of an operator to an argument.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Strength<T> {
+    /// This is the strongly associated side of the operator.
+    Strong(T),
+
+    /// This is the weakly associated side of the operator.
+    Weak(T),
+}
+
+impl<T> Strength<T> {
+    /// Get the binding strength, ignoring associativity.
+    pub fn strength(&self) -> &T {
+        match self {
+            Self::Strong(strength) => strength,
+            Self::Weak(strength) => strength,
+        }
+    }
+}
+
+impl<T: Ord> Strength<T> {
+    /// Compare two strengths.
+    ///
+    /// `None` is considered less strong than any `Some(Strength<T>)`,
+    /// as it's used to indicate the lack of an operator
+    /// to the left of the first expression and cannot bind.
+    fn is_lt(&self, other: &Option<Self>) -> bool {
+        match (self, other) {
+            (x, Some(y)) => x < y,
+            (_, None) => false,
+        }
+    }
+}
+
+impl<T: PartialOrd> PartialOrd for Strength<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.strength().partial_cmp(other.strength()) {
+            Some(Ordering::Equal) => match (self, other) {
+                (Self::Strong(_), Self::Weak(_)) => Some(cmp::Ordering::Greater),
+                (Self::Weak(_), Self::Strong(_)) => Some(cmp::Ordering::Less),
+                _ => Some(cmp::Ordering::Equal),
+            },
+            ord => ord,
+        }
+    }
+}
+
+impl<T: Ord> Ord for Strength<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+/// Defines the parsing precedence of an operator.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct InfixPrecedence<T> {
+    strength: T,
+    associativity: Associativity,
+}
+
+impl<T> InfixPrecedence<T> {
+    /// Create a new precedence value.
+    pub fn new(strength: T, associativity: Associativity) -> Self {
+        Self {
+            strength,
+            associativity,
+        }
+    }
+}
+
+impl<T: Ord + Copy> InfixPrecedence<T> {
+    /// Get the binding power of this operator with an argument on the left.
+    fn strength_left(&self) -> Strength<T> {
+        match self.associativity {
+            Associativity::Left => Strength::Weak(self.strength),
+            Associativity::Right => Strength::Strong(self.strength),
+        }
+    }
+
+    /// Get the binding power of this operator with an argument on the right.
+    fn strength_right(&self) -> Strength<T> {
+        match self.associativity {
+            Associativity::Left => Strength::Strong(self.strength),
+            Associativity::Right => Strength::Weak(self.strength),
+        }
+    }
+}
+
+/// Enable Pratt parsing for a binary infix operator.
+pub trait InfixOperator<Expr> {
+    /// The type used to represent operator binding strength.
+    ///
+    /// Unless you have more than 256 operators,
+    /// [`u8`] should be a good choice.
+    type Strength: Copy + Ord;
+
+    /// Get the parsing precedence of this operator.
+    ///
+    /// If an expression has an operator on both sides,
+    /// the one with the greatest strength will
+    /// be built first.
+    ///
+    /// For example, given `x + y * z` where `*` has a greater strength
+    /// than `+` (as usual), the `y` will be combined with the `z` first.
+    /// Next, the combination `(y * z)` will be combined with `x`,
+    /// resulting in `(x + (y * z))`.
+    ///
+    /// If both sides have operators with the same strength,
+    /// then the associativity will determine which side
+    /// will be combined first.
+    ///
+    /// For example, given `x + y + z`;
+    /// left-associativity will result in `((x + y) + z)`,
+    /// while right-associativity will result in `(x + (y + z))`,
+    fn precedence(&self) -> InfixPrecedence<Self::Strength>;
+
+    /// Build an expression for this operator given two arguments.
+    fn build_expression(self, left: Expr, right: Expr) -> Expr;
+}
+
+/// See [`pratt()`].
+#[derive(Copy, Clone)]
+pub struct Pratt<Extra, AtomParser, Expr, OpParser, Op> {
+    pub(crate) parser_op: OpParser,
+    pub(crate) parser_atom: AtomParser,
+    pub(crate) phantom: PhantomData<(Extra, Expr, Op)>,
+}
+
+/// Use Pratt parsing to efficiently parse binary operators
+/// with different associativity.
+///
+/// The parsing algorithm currently uses recursion
+/// to parse nested expressions.
+///
+/// # Examples
+///
+/// ```
+/// use chumsky::zero_copy::prelude::*;
+/// use chumsky::zero_copy::pratt::{pratt, InfixOperator, InfixPrecedence, Associativity};
+///
+/// #[derive(Clone, Copy, Debug)]
+/// enum Operator {
+///     Add,
+///     Sub,
+///     Mul,
+///     Div,
+/// }
+///
+/// enum Expr {
+///     Literal(i64),
+///     Add(Box<Expr>, Box<Expr>),
+///     Sub(Box<Expr>, Box<Expr>),
+///     Mul(Box<Expr>, Box<Expr>),
+///     Div(Box<Expr>, Box<Expr>),
+/// }
+///
+/// impl std::fmt::Display for Expr {
+///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+///         match self {
+///             Self::Literal(literal) => write!(f, "{literal}"),
+///             Self::Add(left, right) => write!(f, "({left} + {right})"),
+///             Self::Sub(left, right) => write!(f, "({left} - {right})"),
+///             Self::Mul(left, right) => write!(f, "({left} * {right})"),
+///             Self::Div(left, right) => write!(f, "({left} / {right})"),
+///         }
+///     }
+/// }
+///
+/// impl InfixOperator<Expr> for Operator {
+///     type Strength = u8;
+///
+///     fn precedence(&self) -> InfixPrecedence<Self::Strength> {
+///         // NOTE: Usually, in Rust for example, all these operators
+///         // are left-associative. However, in this example we define
+///         // then with different associativities for demonstration purposes.
+///         // (Although it doesn't really matter here since these operations
+///         // are commutative for integers anyway.)
+///         match self {
+///             Self::Add => InfixPrecedence::new(0, Associativity::Left),
+///             Self::Sub => InfixPrecedence::new(0, Associativity::Left),
+///             Self::Mul => InfixPrecedence::new(1, Associativity::Right),
+///             Self::Div => InfixPrecedence::new(1, Associativity::Right),
+///         }
+///     }
+///
+///     fn build_expression(self, left: Expr, right: Expr) -> Expr {
+///         let (left, right) = (Box::new(left), Box::new(right));
+///         match self {
+///             Self::Add => Expr::Add(left, right),
+///             Self::Sub => Expr::Sub(left, right),
+///             Self::Mul => Expr::Mul(left, right),
+///             Self::Div => Expr::Div(left, right),
+///         }
+///     }
+/// }
+///
+/// let atom = text::int::<_, _, extra::Default>(10)
+///     .from_str()
+///     .unwrapped()
+///     .map(Expr::Literal);
+///
+/// let operator = choice((
+///     just('+').to(Operator::Add),
+///     just('-').to(Operator::Sub),
+///     just('*').to(Operator::Mul),
+///     just('/').to(Operator::Div),
+/// ));
+///
+/// let expr = pratt(atom, operator.padded_by(just(' ')));
+/// let expr_str = expr.map(|expr| expr.to_string()).then_ignore(end());
+/// assert_eq!(expr_str.parse("1 + 2").into_result(), Ok("(1 + 2)".to_string()));
+/// // `*` binds more strongly than `+`
+/// assert_eq!(expr_str.parse("1 * 2 + 3").into_result(), Ok("((1 * 2) + 3)".to_string()));
+/// assert_eq!(expr_str.parse("1 + 2 * 3").into_result(), Ok("(1 + (2 * 3))".to_string()));
+/// // `+` is left-associative
+/// assert_eq!(expr_str.parse("1 + 2 + 3").into_result(), Ok("((1 + 2) + 3)".to_string()));
+/// // `*` is right-associative (in this example)
+/// assert_eq!(expr_str.parse("1 * 2 * 3").into_result(), Ok("(1 * (2 * 3))".to_string()));
+/// ```
+pub fn pratt<'a, I, Extra, AtomParser, Expr, OpParser, Op>(
+    parser_atom: AtomParser,
+    parser_op: OpParser,
+) -> impl Parser<'a, I, Expr, Extra>
+where
+    I: Input + ?Sized,
+    Extra: ParserExtra<'a, I>,
+    Op: InfixOperator<Expr>,
+    AtomParser: Parser<'a, I, Expr, Extra>,
+    OpParser: Parser<'a, I, Op, Extra>,
+{
+    Pratt {
+        parser_atom,
+        parser_op,
+        phantom: PhantomData,
+    }
+}
+
+impl<E, AtomParser, Expr, OpParser, Op> Pratt<E, AtomParser, Expr, OpParser, Op> {
+    fn pratt_parse<'a, M, I>(
+        &self,
+        inp: &mut InputRef<'a, '_, I, E>,
+        min_strength: Option<Strength<Op::Strength>>,
+    ) -> PResult<M, Expr, E::Error>
+    where
+        I: Input + ?Sized,
+        E: ParserExtra<'a, I>,
+        AtomParser: Parser<'a, I, Expr, E>,
+        OpParser: Parser<'a, I, Op, E>,
+        Op: InfixOperator<Expr>,
+        M: Mode,
+    {
+        let mut left = self.parser_atom.go::<M>(inp)?;
+        loop {
+            let pre_op = inp.save();
+            let (op, prec) = match self.parser_op.go::<Emit>(inp) {
+                Ok(op) => {
+                    let prec = op.precedence();
+                    if prec.strength_left().is_lt(&min_strength) {
+                        inp.rewind(pre_op);
+                        return Ok(left);
+                    }
+                    (op, prec)
+                }
+                Err(_) => return Ok(left),
+            };
+
+            let right = self.pratt_parse::<M, _>(inp, Some(prec.strength_right()))?;
+            left = M::combine(left, right, |l: Expr, r: Expr| op.build_expression(l, r));
+        }
+    }
+}
+
+impl<'a, I, E, Expr, AtomParser, OpParser, Op> Parser<'a, I, Expr, E>
+    for Pratt<E, AtomParser, Expr, OpParser, Op>
+where
+    I: Input + ?Sized,
+    E: ParserExtra<'a, I>,
+    AtomParser: Parser<'a, I, Expr, E>,
+    OpParser: Parser<'a, I, Op, E>,
+    Op: InfixOperator<Expr>,
+{
+    fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, Expr, E::Error>
+    where
+        Self: Sized,
+    {
+        self.pratt_parse::<M, _>(inp, None)
+    }
+
+    go_extra!(Expr);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zero_copy::error::Simple;
+
+    #[derive(Clone, Copy, Debug)]
+    enum Operator {
+        Add,
+        Sub,
+        Mul,
+        Div,
+    }
+
+    enum Expr {
+        Literal(i64),
+        Add(Box<Expr>, Box<Expr>),
+        Sub(Box<Expr>, Box<Expr>),
+        Mul(Box<Expr>, Box<Expr>),
+        Div(Box<Expr>, Box<Expr>),
+    }
+
+    impl std::fmt::Display for Expr {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Literal(literal) => write!(f, "{literal}"),
+                Self::Add(left, right) => write!(f, "({left} + {right})"),
+                Self::Sub(left, right) => write!(f, "({left} - {right})"),
+                Self::Mul(left, right) => write!(f, "({left} * {right})"),
+                Self::Div(left, right) => write!(f, "({left} / {right})"),
+            }
+        }
+    }
+
+    impl InfixOperator<Expr> for Operator {
+        type Strength = u8;
+
+        fn precedence(&self) -> InfixPrecedence<Self::Strength> {
+            match self {
+                Self::Add => InfixPrecedence::new(0, Associativity::Left),
+                Self::Sub => InfixPrecedence::new(0, Associativity::Left),
+                Self::Mul => InfixPrecedence::new(1, Associativity::Right),
+                Self::Div => InfixPrecedence::new(1, Associativity::Right),
+            }
+        }
+
+        fn build_expression(self, left: Expr, right: Expr) -> Expr {
+            let (left, right) = (Box::new(left), Box::new(right));
+            match self {
+                Self::Add => Expr::Add(left, right),
+                Self::Sub => Expr::Sub(left, right),
+                Self::Mul => Expr::Mul(left, right),
+                Self::Div => Expr::Div(left, right),
+            }
+        }
+    }
+
+    fn parser<'a>() -> impl Parser<'a, str, String, extra::Err<Rich<str>>> {
+        let atom = super::text::int(10)
+            .from_str()
+            .unwrapped()
+            .map(Expr::Literal);
+
+        let operator = choice((
+            just('+').to(Operator::Add),
+            just('-').to(Operator::Sub),
+            just('*').to(Operator::Mul),
+            just('/').to(Operator::Div),
+        ));
+
+        pratt(atom, operator).map(|x| x.to_string())
+    }
+
+    fn complete_parser<'a>() -> impl Parser<'a, str, String, extra::Err<Rich<str>>> {
+        parser().then_ignore(end())
+    }
+
+    fn parse(input: &str) -> ParseResult<String, Rich<str>> {
+        complete_parser().parse(input)
+    }
+
+    fn parse_partial(input: &str) -> ParseResult<String, Rich<str>> {
+        parser().parse(input)
+    }
+
+    #[test]
+    fn missing_first_expression() {
+        assert_eq!(
+            parse("").into_result(),
+            Err(vec![Rich::expected_found(
+                Some(Some('0')),
+                None,
+                (0..0).into()
+            )])
+        )
+    }
+
+    #[test]
+    fn missing_later_expression() {
+        assert_eq!(
+            parse("1+").into_result(),
+            Err(vec![Rich::expected_found(
+                Some(Some('0')),
+                None,
+                (2..2).into()
+            )]),
+        );
+    }
+
+    #[test]
+    fn invalid_first_expression() {
+        assert_eq!(
+            parse("?").into_result(),
+            Err(vec![Rich::expected_found(
+                Some(Some('0')),
+                // Should this not be: Some('?')?
+                None,
+                (0..1).into(),
+            )]),
+        );
+    }
+
+    #[test]
+    fn invalid_later_expression() {
+        assert_eq!(
+            parse("1+?").into_result(),
+            Err(vec![Rich::expected_found(
+                Some(Some('0')),
+                // Should this not be: Some('?')?
+                None,
+                (2..3).into(),
+            )]),
+        );
+    }
+
+    #[test]
+    fn invalid_operator() {
+        assert_eq!(
+            parse("1?").into_result(),
+            Err(vec![Rich::expected_found(None, Some('?'), (1..2).into(),)]),
+        );
+    }
+
+    #[test]
+    fn invalid_operator_incomplete() {
+        assert_eq!(parse_partial("1?").into_result(), Ok("1".to_string()),);
+    }
+
+    #[test]
+    fn complex_nesting() {
+        assert_eq!(
+            parse_partial("1+2*3/4*5-6*7+8-9+10").into_result(),
+            Ok("(((((1 + (2 * (3 / (4 * 5)))) - (6 * 7)) + 8) - 9) + 10)".to_string()),
+        );
+    }
+}


### PR DESCRIPTION
### What is this PR?

This PR is a near 1:1 implementation of #144, updated to match `zero-copy` with the change that `pratt` is now function of the `Parser` trait (as seen in the second commit)

### API Concerns

In #144 @zesterer expressed their concerns regarding the mismatched API between this function and the rest of the crate. For this reason I went and did some brainstorming for a nice middle-ground between flexibility and matching the API of the crate. Here is a quick rundown of what I have in mind. Please let me know if/how it fits and if it is something that I should invest more time in implementing. This is currently just a rough draft, and as such I didn't spend a lot of time working out the generics.

#### User Side

The `Parser::pratt` function would now have a similar API to `Choice`, but instead of a tuple, the user would supply an array of `PrattOp` structs:

```rust
atom.pratt([
    PrattOp::new_left(0, just('+'), Expr::Add),
    PrattOp::new_left(0, just('-'), Expr::Sub),
    PrattOp::new_right(1, just('*'), Expr::Mul),
    PrattOp::new_right(1, just('/'), Expr::Div),
])
```

This `PrattOp` struct would be used to internalize the logic of `InfixPrecedence` as well as removing the necessity for `InfixOperator` and the `Operator` enum used in the examples provided by the original author of #144. `InfixPrecedence` and `Associativity` would, just like `Strength`, become internal implementation details and *not* be exposed to the user.

#### Developer Side

On `chumsky`'s side the implementation does get a little trickier, but I think it's  manageable. The `[PrattOp; N]` passed via the `Parser::pratt` function would be stored in a `PrattOperatorParser`.

```rust

pub struct PrattOp<I, O, E, Expr, P = u8> {
    prec: InfixPrecedence<P>,
    parser: Parser<I, O, E>,
    build: Fn(l: Expr, r: Expr) -> Expr
}

pub(crate) struct PrattOperatorParser<N: usize, I, O, E, Expr, P = u8> { 
    ops: [PrattOp<I, O, E, Expr, P>; N],
}
```

In the implementation of `Parser` for `PrattOperatorParser` instead of returning the operator it returns the `InfixPrecedence` and `build` function of the successful `PrattOp`. This is a small improvement over the current situation, because right now the operator parser must emit the operator, in order to get the precedence and the build function. Here is an example of how it's implementation could look like:

```rust
impl Parser for OpParser {
    fn go(&self, inp: &mut InputRef) -> PResult<Emit, (InfixPrecedence, F), E::Error> {
        let before = inp.save();
        let mut error: Option<Located<_> = None;

        for op in &self.ops {
            match op.parser.go::<Check>() {
                Ok(_) => return Ok(op.prec, op.build.clone()),
                Err(e) => {
                    err = Some(match err {
                        Some(err) => err.prioritize(e, |a, b| a.merge(b)),
                        None => e,
                    });
                    inp.rewind(before);
                }
            }
        }

        Err(err.unwrap_or_else(|| Located::at(inp.offset().into(), E::Error::expected_found(None, None, inp.span_since(before.offset)))))
    }
}
```

#### Final Remarks

With this change user's would have less boilerplate in writing their own Pratt-parsers, and the parser could be expanded in the future to include suffix and prefix operators via functions like `PrattOp::suffix` and `PrattOp::prefix`.

Do you feel that this would fit the rest of the API? Do you feel like this is something that could be of use in the current `zero-copy` branch? What concerns do you have about the idea or what problems could you see in its implementation?

Thanks for your time!