### PR TITLE
bench(json): Include winnow in the cross-parser compare

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ regex = { version = "1.7", optional = true }
 ariadne = "0.1.5"
 pom = "3.2"
 nom = "7.1"
+winnow = "0.3"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 criterion = "0.4.0"
 pest = "2.5"

--- a/benches/json.rs
+++ b/benches/json.rs
@@ -31,6 +31,10 @@ fn bench_json(c: &mut Criterion) {
         move |b| b.iter(|| black_box(nom::json(black_box(JSON)).unwrap()))
     });
 
+    c.bench_function("json_winnow", {
+        move |b| b.iter(|| black_box(winnow::json(black_box(JSON)).unwrap()))
+    });
+
     c.bench_function("json_chumsky_zero_copy", {
         use ::chumsky::prelude::*;
         let json = chumsky_zero_copy::json();
@@ -317,6 +321,103 @@ mod nom {
     }
 
     pub fn json<'a>(i: &'a [u8]) -> IResult<&'a [u8], JsonZero, (&'a [u8], nom::error::ErrorKind)> {
+        root(i)
+    }
+}
+
+mod winnow {
+    use winnow::{
+        branch::alt,
+        bytes::{none_of, one_of, tag, take_while0},
+        character::{digit0, digit1, escaped},
+        combinator::{cut_err, opt},
+        error::{Error, ParseError},
+        multi::separated0,
+        prelude::*,
+        sequence::{preceded, separated_pair, terminated},
+    };
+
+    use super::JsonZero;
+    use std::str;
+
+    fn space<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
+        take_while0(|c| b" \t\r\n".contains(&c))(i)
+    }
+
+    fn number<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], f64, E> {
+        (
+            opt('-'),
+            alt(((one_of("123456789"), digit0).void(), one_of('0').void())),
+            opt(('.', digit1)),
+            opt((one_of("eE"), opt(one_of("+-")), cut_err(digit1))),
+        )
+            .recognize()
+            .map(|bytes| str::from_utf8(bytes).unwrap().parse::<f64>().unwrap())
+            .parse_next(i)
+    }
+
+    fn string<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], &'a [u8], E> {
+        preceded(
+            '"',
+            cut_err(terminated(
+                escaped(none_of("\\\""), '\\', one_of("\\/\"bfnrt")),
+                '"',
+            )),
+        )(i)
+    }
+
+    fn array<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], Vec<JsonZero>, E> {
+        preceded(
+            '[',
+            cut_err(terminated(
+                separated0(value, preceded(space, ',')),
+                preceded(space, ']'),
+            )),
+        )(i)
+    }
+
+    fn member<'a, E: ParseError<&'a [u8]>>(
+        i: &'a [u8],
+    ) -> IResult<&'a [u8], (&'a [u8], JsonZero), E> {
+        separated_pair(
+            preceded(space, string),
+            cut_err(preceded(space, ':')),
+            value,
+        )(i)
+    }
+
+    fn object<'a, E: ParseError<&'a [u8]>>(
+        i: &'a [u8],
+    ) -> IResult<&'a [u8], Vec<(&'a [u8], JsonZero)>, E> {
+        preceded(
+            '{',
+            cut_err(terminated(
+                separated0(member, preceded(space, ',')),
+                preceded(space, '}'),
+            )),
+        )(i)
+    }
+
+    fn value<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], JsonZero, E> {
+        preceded(
+            space,
+            alt((
+                tag("null").value(JsonZero::Null),
+                tag("true").value(JsonZero::Bool(true)),
+                tag("false").value(JsonZero::Bool(false)),
+                number.map(JsonZero::Num),
+                string.map(JsonZero::Str),
+                array.map(JsonZero::Array),
+                object.map(JsonZero::Object),
+            )),
+        )(i)
+    }
+
+    fn root<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) -> IResult<&'a [u8], JsonZero, E> {
+        terminated(value, space)(i)
+    }
+
+    pub fn json<'a>(i: &'a [u8]) -> IResult<&'a [u8], JsonZero, Error<&'a [u8]>> {
         root(i)
     }
 }


### PR DESCRIPTION
`winnow` is a recent fork of `nom` that is being used by `tonl_edit` / `toml`.

`winnow` seems to be taking half the time of `nom` and I had to check
the output to confirm there wasn't a bug.  I dumped the `JsonZero`
structure from both parsers and diffed it and it was the same.

On my machine
```
json_nom
                        time:   [385.34 µs 386.74 µs 388.21 µs]
json_winnow
                        time:   [160.89 µs 161.85 µs 162.91 µs]
json_chumsky_zero_copy
                        time:   [265.28 µs 266.16 µs 267.06 µs]
```
These results are a complete surprise to me with `winnow` being the fastest parser combinator library, coming in at less than half the parse time  `nom`.  For `toml_edit`, `winnow` takes only 20% less time which I **think** I narrowed down to an extra `#[inline]`.  In this case, the main difference that I can think of is the use of `escaped` as its rewritten in `winnow` and `toml_edit` doesn't use it.