### PR TITLE
Replace `repeated_exactly` and `separated_by_exactly` with `collect_exactly`

### DIFF
--- a/benches/cbor.rs
+++ b/benches/cbor.rs
@@ -181,14 +181,14 @@ mod chumsky_zero_copy {
                 simple(26).ignore_then(
                     any()
                         .repeated()
-                        .collect_exactly::<[_; 4]>()
+                        .collect_exactly::<4, _>()
                         .map(f32::from_be_bytes)
                         .map(CborZero::SingleFloat),
                 ),
                 simple(27).ignore_then(
                     any()
                         .repeated()
-                        .collect_exactly::<[_; 8]>()
+                        .collect_exactly::<8, _>()
                         .map(f64::from_be_bytes)
                         .map(CborZero::DoubleFloat),
                 ),

--- a/benches/cbor.rs
+++ b/benches/cbor.rs
@@ -181,14 +181,14 @@ mod chumsky_zero_copy {
                 simple(26).ignore_then(
                     any()
                         .repeated()
-                        .collect_exactly::<4, _>()
+                        .collect_exactly()
                         .map(f32::from_be_bytes)
                         .map(CborZero::SingleFloat),
                 ),
                 simple(27).ignore_then(
                     any()
                         .repeated()
-                        .collect_exactly::<8, _>()
+                        .collect_exactly()
                         .map(f64::from_be_bytes)
                         .map(CborZero::DoubleFloat),
                 ),

--- a/benches/cbor.rs
+++ b/benches/cbor.rs
@@ -180,15 +180,15 @@ mod chumsky_zero_copy {
                 simple(23).to(CborZero::Undef),
                 simple(26).ignore_then(
                     any()
-                        .repeated_exactly::<4>()
-                        .collect()
+                        .repeated()
+                        .collect_exactly::<[_; 4]>()
                         .map(f32::from_be_bytes)
                         .map(CborZero::SingleFloat),
                 ),
                 simple(27).ignore_then(
                     any()
-                        .repeated_exactly::<8>()
-                        .collect()
+                        .repeated()
+                        .collect_exactly::<[_; 8]>()
                         .map(f64::from_be_bytes)
                         .map(CborZero::DoubleFloat),
                 ),

--- a/examples/zero-copy.rs
+++ b/examples/zero-copy.rs
@@ -23,8 +23,8 @@ fn parser<'a>() -> impl Parser<'a, &'a str, [(SimpleSpan<usize>, Token<'a>); 6]>
         .or(string)
         .map_with_span(|token, span| (span, token))
         .padded()
-        .repeated_exactly()
-        .collect()
+        .repeated()
+        .collect_exactly()
 }
 
 fn main() {

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1616,13 +1616,13 @@ where
 }
 
 /// See [`IterParser::collect_exactly`]
-pub struct CollectExactly<A, O, C, const N: usize> {
+pub struct CollectExactly<A, O, C> {
     pub(crate) parser: A,
     pub(crate) phantom: PhantomData<(O, C)>,
 }
 
-impl<A: Copy, O, C, const N: usize> Copy for CollectExactly<A, O, C, N> {}
-impl<A: Clone, O, C, const N: usize> Clone for CollectExactly<A, O, C, N> {
+impl<A: Copy, O, C> Copy for CollectExactly<A, O, C> {}
+impl<A: Clone, O, C> Clone for CollectExactly<A, O, C> {
     fn clone(&self) -> Self {
         Self {
             parser: self.parser.clone(),
@@ -1631,19 +1631,19 @@ impl<A: Clone, O, C, const N: usize> Clone for CollectExactly<A, O, C, N> {
     }
 }
 
-impl<'a, I, O, E, A, C, const N: usize> Parser<'a, I, C, E> for CollectExactly<A, O, C, N>
+impl<'a, I, O, E, A, C> Parser<'a, I, C, E> for CollectExactly<A, O, C>
 where
     I: Input<'a>,
     E: ParserExtra<'a, I>,
     A: IterParser<'a, I, O, E>,
-    C: ContainerExactly<O, N>,
+    C: ContainerExactly<O>,
 {
     #[inline]
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, C> {
         let before = inp.offset();
         let mut output = M::bind(|| C::uninit());
         let mut iter_state = self.parser.make_iter::<M>(inp)?;
-        for idx in 0..N {
+        for idx in 0..C::LEN {
             match self.parser.next::<M>(inp, &mut iter_state) {
                 Ok(Some(out)) => {
                     M::combine_mut(&mut output, out, |c, out| C::write(c, idx, out));

--- a/src/container.rs
+++ b/src/container.rs
@@ -5,6 +5,7 @@ use alloc::collections::LinkedList;
 use hashbrown::HashSet;
 
 /// A utility trait for types that can be constructed from a series of items.
+// TODO: Wrapper impls - Box, etc
 pub trait Container<T>: Default {
     /// Create a container, attempting to pre-allocate enough space for `n` items.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ use crate::input::InputOwn;
 use alloc::{
     boxed::Box,
     rc::{Rc, Weak},
+    sync::Arc,
     string::String,
     vec,
     vec::Vec,
@@ -1890,7 +1891,7 @@ pub trait IterParser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default
     /// assert!(three_digit.parse("12").into_result().is_err());
     /// assert!(three_digit.parse("1234").into_result().is_err());
     /// ```
-    fn collect_exactly<const N: usize, C: ContainerExactly<O, N>>(self) -> CollectExactly<Self, O, C, N>
+    fn collect_exactly<C: ContainerExactly<O>>(self) -> CollectExactly<Self, O, C>
     where
         Self: Sized,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1886,7 +1886,7 @@ pub trait IterParser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default
     /// # use chumsky::{prelude::*, error::Simple};
     /// let three_digit = any::<_, extra::Err<Simple<char>>>().filter(|c: &char| c.is_numeric())
     ///     .repeated()
-    ///     .collect_exactly::<3, _>();
+    ///     .collect_exactly::<[_; 3]>();
     ///
     /// assert_eq!(three_digit.parse("123").into_result(), Ok(['1', '2', '3']));
     /// assert!(three_digit.parse("12").into_result().is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ use alloc::{
 };
 use core::{
     borrow::Borrow,
+    cell::UnsafeCell,
     cmp::{Eq, Ordering},
     fmt,
     hash::Hash,


### PR DESCRIPTION
CBOR benchmark doesn't show a notable regression, so that's an added plus