### PR TITLE
Use new `cargo-semver-checks-action`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check semver compatibility
-        uses: obi1kenobi/cargo-semver-checks-action@main
+        uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           rust-toolchain: nightly

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,11 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest nightly
-        uses: dtolnay/rust-toolchain@master
-        with:
-            toolchain: nightly
-      - name: Install cargo-semver-checks
-        run: cargo install cargo-semver-checks --locked
       - name: Check semver compatibility
-        run: cargo semver-checks check-release
+        uses: obi1kenobi/cargo-semver-checks-action@main
+        with:
+          rust-toolchain: nightly


### PR DESCRIPTION
Hi! As one of the contributors of `cargo-semver-checks` I'd want to say we're pleased to see you're using our tool!

Since we've recently released a new, completely rebuilt version of the GitHub action, you can now use it instead of installing `cargo-semver-checks` manually in CI. The new action handles the setup of Rust toolchain, downloads prebuilt binary of the latest `cargo-semver-checks` instead of building it from source and caches the baseline rustdoc between the runs. These all results in huge speedup of the semver job - less than 1m 30s compared to 6 minutes before.