### PR TITLE
Fixed examples, added to_span combinator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ pest_derive = "2.5"
 sn = "0.1"
 logos = "0.12"
 lasso = "0.7"
+slotmap = "1.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.11", features = ["flamegraph", "criterion"] }

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -44,21 +44,9 @@ pub type Err<E> = Full<E, DefaultState, DefaultCtx>;
 /// Use specified state type, but default other types. See [`ParserExtra`] for more details.
 ///
 /// Use `State<S>` or `Full<E, S, C>` as the `Extra` type parameter of a parser to use a custom state type.
-/// You can then use `parser().parse_with_state(&mut S)` to parse with a custom state
+/// You can then use `parser().parse_with_state(&mut S)` to parse with a custom state.
 ///
-/// # Examples
-///
-/// One common use case for this is arena allocation of AST Nodes or tokens.
-///
-/// ```
-/// type ParserState = SlotMap<NodeId, ASTNode>;
-///
-/// // Use a slotmap to allocate AST nodes, returning an id from each parser instead of a node
-/// pub fn parser<'src>() -> impl Parser<'src, &'src [Token], NodeId, extra::State<ParserState>> {
-///     // ...
-/// }
-/// ```
-///
+/// See [`Parser::map_with_state`] for examples.
 pub type State<S> = Full<DefaultErr, S, DefaultCtx>;
 
 /// Use specified context type, but default other types. See [`ParserExtra`] for more details.

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -5,6 +5,7 @@ use super::*;
 /// See [`regex()`].
 pub struct Regex<C: Char, I, E> {
     regex: C::Regex,
+    #[allow(dead_code)]
     phantom: EmptyPhantom<(E, I)>,
 }
 

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -5,14 +5,27 @@ use super::*;
 /// See [`regex()`].
 pub struct Regex<C: Char, I, E> {
     regex: C::Regex,
-    phantom: PhantomData<(E, I)>,
+    phantom: EmptyPhantom<(E, I)>,
+}
+
+impl<C: Char, I, E> Copy for Regex<C, I, E> where C::Regex: Copy {}
+impl<C: Char, I, E> Clone for Regex<C, I, E>
+where
+    C::Regex: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            regex: self.regex.clone(),
+            phantom: EmptyPhantom::new(),
+        }
+    }
 }
 
 /// Match input based on a provided regex pattern
 pub fn regex<C: Char, I, E>(pattern: &str) -> Regex<C, I, E> {
     Regex {
         regex: C::new_regex(pattern),
-        phantom: PhantomData,
+        phantom: EmptyPhantom::new(),
     }
 }
 


### PR DESCRIPTION
It's still not entirely clear to me whether the combinator should be called `span` or `to_span`. I've gone for the latter for now to avoid the combinator type name conflicting with the trait.