### PR TITLE
Add support for unicode identifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ sync = ["spin"]
 
 # Adds impl of Parser for either::Either
 either = ["dep:either"]
+# Enable support for unicode identifiers
+unicode = ["dep:unicode-ident"]
 
 # An alias of all features that work with the stable compiler.
 # Do not use this feature, its removal is not considered a breaking change and its behaviour may change.
@@ -56,6 +58,7 @@ stacker = { version = "0.1", optional = true }
 regex = { version = "1.7", optional = true }
 spin = { version = "0.9", features = ["once"], default-features = false, optional = true }
 either = { version = "1.8.1", optional = true }
+unicode-ident = {version = "1.0.9", optional = true}
 
 [dev-dependencies]
 ariadne = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,6 @@ sync = ["spin"]
 
 # Adds impl of Parser for either::Either
 either = ["dep:either"]
-# Enable support for unicode identifiers
-unicode = ["dep:unicode-ident"]
 
 # An alias of all features that work with the stable compiler.
 # Do not use this feature, its removal is not considered a breaking change and its behaviour may change.
@@ -58,7 +56,7 @@ stacker = { version = "0.1", optional = true }
 regex = { version = "1.7", optional = true }
 spin = { version = "0.9", features = ["once"], default-features = false, optional = true }
 either = { version = "1.8.1", optional = true }
-unicode-ident = {version = "1.0.9", optional = true}
+unicode-ident =  "1.0.9"
 
 [dev-dependencies]
 ariadne = "0.2"

--- a/benches/lex.rs
+++ b/benches/lex.rs
@@ -174,7 +174,7 @@ mod chumsky_zero_copy {
             .delimited_by(just(b'"'), just(b'"'))
             .boxed();
 
-        let ident = text::ident().map_slice(Token::Ident);
+        let ident = text::ascii::ident().map_slice(Token::Ident);
 
         choice((
             just(b"null").to(Token::Null),

--- a/examples/foo.rs
+++ b/examples/foo.rs
@@ -28,7 +28,7 @@ enum Expr<'a> {
 }
 
 fn parser<'a>() -> impl Parser<'a, &'a str, Expr<'a>> {
-    let ident = text::ident().padded();
+    let ident = text::ascii::ident().padded();
 
     let expr = recursive(|expr| {
         let int = text::int(10)
@@ -80,7 +80,7 @@ fn parser<'a>() -> impl Parser<'a, &'a str, Expr<'a>> {
     });
 
     let decl = recursive(|decl| {
-        let r#let = text::keyword("let")
+        let r#let = text::ascii::keyword("let")
             .ignore_then(ident)
             .then_ignore(just('='))
             .then(expr.clone())
@@ -92,7 +92,7 @@ fn parser<'a>() -> impl Parser<'a, &'a str, Expr<'a>> {
                 then: Box::new(then),
             });
 
-        let r#fn = text::keyword("fn")
+        let r#fn = text::ascii::keyword("fn")
             .ignore_then(ident)
             .then(ident.repeated().collect::<Vec<_>>())
             .then_ignore(just('='))

--- a/examples/nano_rust.rs
+++ b/examples/nano_rust.rs
@@ -67,7 +67,7 @@ fn lexer<'src>(
     let ctrl = one_of("()[]{};,").map(Token::Ctrl);
 
     // A parser for identifiers and keywords
-    let ident = text::ident().map(|ident: &str| match ident {
+    let ident = text::ascii::ident().map(|ident: &str| match ident {
         "fn" => Token::Fn,
         "let" => Token::Let,
         "print" => Token::Print,

--- a/examples/pythonic.rs
+++ b/examples/pythonic.rs
@@ -37,7 +37,7 @@ fn lexer<'a>() -> impl Parser<'a, str, Vec<Spanned<TokenTree>>> {
             .from_str()
             .unwrapped()
             .map(Token::Int);
-        let ident = text::ident::<'a, str, _, _, _>().map(|s| Token::Ident(s.to_string()));
+        let ident = text::ascii::ident::<'a, str, _, _, _>().map(|s| Token::Ident(s.to_string()));
         let op = one_of("=.:%,")
             .repeated()
             .at_least(1)

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1592,7 +1592,7 @@ where
     ///
     /// ```
     /// # use chumsky::prelude::*;
-    /// let r#enum = text::keyword::<_, _, _, extra::Err<Simple<char>>>("enum")
+    /// let r#enum = text::ascii::keyword::<_, _, _, extra::Err<Simple<char>>>("enum")
     ///     .padded()
     ///     .ignore_then(text::ascii::ident()
     ///         .padded()

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -1594,7 +1594,7 @@ where
     /// # use chumsky::prelude::*;
     /// let r#enum = text::keyword::<_, _, _, extra::Err<Simple<char>>>("enum")
     ///     .padded()
-    ///     .ignore_then(text::ident()
+    ///     .ignore_then(text::ascii::ident()
     ///         .padded()
     ///         .separated_by(just('|'))
     ///         .allow_leading()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,7 +506,7 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     /// #[derive(Debug, PartialEq)]
     /// pub struct Spanned<T>(T, SimpleSpan<usize>);
     ///
-    /// let ident = text::ident::<_, _, extra::Err<Simple<char>>>()
+    /// let ident = text::ascii::ident::<_, _, extra::Err<Simple<char>>>()
     ///     .map_with_span(Spanned) // Equivalent to `.map_with_span(|ident, span| Spanned(ident, span))`
     ///     .padded();
     ///
@@ -595,7 +595,7 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     /// #[derive(Copy, Clone)]
     /// pub struct Ident(Spur);
     ///
-    /// let ident = text::ident::<_, _, extra::Full<Simple<char>, Rodeo, ()>>()
+    /// let ident = text::ascii::ident::<_, _, extra::Full<Simple<char>, Rodeo, ()>>()
     ///     .map_with_state(|ident, span, state| Ident(state.get_or_intern(ident)))
     ///     .padded()
     ///     .repeated()
@@ -1148,7 +1148,7 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     ///
     /// ```
     /// # use chumsky::{prelude::*, error::Simple};
-    /// let ident = text::ident::<_, _, extra::Err<Simple<char>>>()
+    /// let ident = text::ascii::ident::<_, _, extra::Err<Simple<char>>>()
     ///     .padded_by(just('!'));
     ///
     /// assert_eq!(ident.parse("!hello!").into_result(), Ok("hello"));
@@ -1354,7 +1354,7 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     ///
     /// ```
     /// # use chumsky::{prelude::*, error::Simple};
-    /// let shopping = text::ident::<_, _, extra::Err<Simple<char>>>()
+    /// let shopping = text::ascii::ident::<_, _, extra::Err<Simple<char>>>()
     ///     .padded()
     ///     .separated_by(just(','))
     ///     .collect::<Vec<_>>();
@@ -1572,7 +1572,7 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     ///
     /// ```
     /// # use chumsky::prelude::*;
-    /// let ident = text::ident::<_, _, extra::Err<Simple<char>>>().padded();
+    /// let ident = text::ascii::ident::<_, _, extra::Err<Simple<char>>>().padded();
     ///
     /// // A pattern with no whitespace surrounding it is accepted
     /// assert_eq!(ident.parse("hello").into_result(), Ok("hello"));
@@ -1777,9 +1777,9 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     ///         });
     ///
     /// // Parser that uses the validation version
-    /// let multi_step_val = large_int_val.then(text::ident().padded());
+    /// let multi_step_val = large_int_val.then(text::ascii::ident().padded());
     /// // Parser that uses the try_map version
-    /// let multi_step_tm = large_int_tm.then(text::ident().padded());
+    /// let multi_step_tm = large_int_tm.then(text::ascii::ident().padded());
     ///
     /// // On success, both parsers are equivalent
     /// assert_eq!(
@@ -2062,7 +2062,7 @@ where
     ///     .unwrapped();
     ///
     /// // By default, accepts any number of items
-    /// let item = text::ident()
+    /// let item = text::ascii::ident()
     ///     .padded()
     ///     .repeated();
     ///
@@ -2229,7 +2229,7 @@ where
     ///
     /// ```
     /// # use chumsky::{prelude::*, error::Simple};
-    /// let word = text::ident::<_, _, extra::Err<Simple<char>>>()
+    /// let word = text::ascii::ident::<_, _, extra::Err<Simple<char>>>()
     ///     .padded()
     ///     .repeated() // This parser is iterable (i.e: implements `IterParser`)
     ///     .enumerate()

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -760,10 +760,10 @@ pub struct Choice<T> {
 /// }
 ///
 /// let tokens = choice((
-///     text::keyword::<_, _, _, extra::Err<Simple<char>>>("if").to(Token::If),
-///     text::keyword("for").to(Token::For),
-///     text::keyword("while").to(Token::While),
-///     text::keyword("fn").to(Token::Fn),
+///     text::ascii::keyword::<_, _, _, extra::Err<Simple<char>>>("if").to(Token::If),
+///     text::ascii::keyword("for").to(Token::For),
+///     text::ascii::keyword("while").to(Token::While),
+///     text::ascii::keyword("fn").to(Token::Fn),
 ///     text::int(10).from_str().unwrapped().map(Token::Int),
 ///     text::ascii::ident().map(Token::Ident),
 /// ))

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -765,7 +765,7 @@ pub struct Choice<T> {
 ///     text::keyword("while").to(Token::While),
 ///     text::keyword("fn").to(Token::Fn),
 ///     text::int(10).from_str().unwrapped().map(Token::Int),
-///     text::ident().map(Token::Ident),
+///     text::ascii::ident().map(Token::Ident),
 /// ))
 ///     .padded()
 ///     .repeated()

--- a/src/recursive.rs
+++ b/src/recursive.rs
@@ -238,7 +238,7 @@ where
 ///     .collect::<Vec<_>>()
 ///     .delimited_by(just('['), just(']'))
 ///     .map(Tree::Branch)
-///     .or(text::ident().map(Tree::Leaf))
+///     .or(text::ascii::ident().map(Tree::Leaf))
 ///     .padded());
 ///
 /// assert_eq!(tree.parse("hello").into_result(), Ok(Tree::Leaf("hello")));

--- a/src/text.rs
+++ b/src/text.rs
@@ -434,7 +434,7 @@ pub mod ascii {
     ///
     /// ```
     /// # use chumsky::prelude::*;
-    /// let def = text::keyword::<_, _, _, extra::Err<Simple<char>>>("def");
+    /// let def = text::ascii::keyword::<_, _, _, extra::Err<Simple<char>>>("def");
     ///
     /// // Exactly 'def' was found
     /// assert_eq!(def.parse("def").into_result(), Ok("def"));
@@ -521,7 +521,7 @@ pub mod unicode {
     ///
     /// ```
     /// # use chumsky::prelude::*;
-    /// let def = text::keyword::<_, _, _, extra::Err<Simple<char>>>("def");
+    /// let def = text::ascii::keyword::<_, _, _, extra::Err<Simple<char>>>("def");
     ///
     /// // Exactly 'def' was found
     /// assert_eq!(def.parse("def").into_result(), Ok("def"));

--- a/src/text.rs
+++ b/src/text.rs
@@ -46,11 +46,9 @@ pub trait Char: Sized + Copy + PartialEq + fmt::Debug + Sealed + 'static {
     /// Returns true if the character is canonically considered to be a numeric digit.
     fn is_digit(&self, radix: u32) -> bool;
 
-    #[cfg(feature = "unicode")]
     /// Returns true if the character is canonically considered to be valid for starting an identifier.
     fn is_ident_start(&self) -> bool;
 
-    #[cfg(feature = "unicode")]
     /// Returns true if the character is canonically considered to be a valid within an identifier.
     fn is_ident_continue(&self) -> bool;
 
@@ -108,12 +106,10 @@ impl Char for char {
         s.chars()
     }
 
-    #[cfg(feature = "unicode")]
     fn is_ident_start(&self) -> bool {
         unicode_ident::is_xid_start(*self)
     }
 
-    #[cfg(feature = "unicode")]
     fn is_ident_continue(&self) -> bool {
         unicode_ident::is_xid_continue(*self)
     }
@@ -152,7 +148,7 @@ impl Char for u8 {
         b'0'
     }
     fn is_digit(&self, radix: u32) -> bool {
-        self.to_char().is_digit(radix)
+        (*self as char).is_digit(radix)
     }
     fn to_char(&self) -> char {
         *self as char
@@ -163,14 +159,12 @@ impl Char for u8 {
         s.iter().copied()
     }
 
-    #[cfg(feature = "unicode")]
     fn is_ident_start(&self) -> bool {
-        self.to_char().is_ascii_alphabetic() || self.to_char() == '_'
+        self.to_char().is_ident_start()
     }
 
-    #[cfg(feature = "unicode")]
     fn is_ident_continue(&self) -> bool {
-        self.to_char().is_ascii_alphanumeric() || self.to_char() == '_'
+        self.to_char().is_ident_continue()
     }
 }
 
@@ -399,154 +393,236 @@ pub fn int<'a, I: ValueInput<'a> + StrInput<'a, C>, C: Char, E: ParserExtra<'a, 
         .slice()
 }
 
-/// A parser that accepts an identifier.
-///
-/// The output type of this parser is [`Char::Str`] (i.e: [`&str`] when `C` is [`char`], and [`&[u8]`] when `C` is
-/// [`u8`]).
-///
-/// An identifier is defined as per "Default Identifiers" in [Unicode Standard Annex #31](https://www.unicode.org/reports/tr31/).
-#[must_use]
-#[cfg(feature = "unicode")]
-pub fn ident<'a, I: ValueInput<'a> + StrInput<'a, C>, C: Char, E: ParserExtra<'a, I>>(
-) -> impl Parser<'a, I, &'a C::Str, E> + Copy + Clone {
-    any()
-        // Use try_map over filter to get a better error on failure
-        .try_map(|c: C, span| {
-            if c.is_ident_start() {
-                Ok(c)
+/// Parsers and utilities for working with ASCII inputs.
+pub mod ascii {
+    use super::*;
+
+    /// A parser that accepts a C-style identifier.
+    ///
+    /// The output type of this parser is [`Char::Str`] (i.e: [`&str`] when `C` is [`char`], and [`&[u8]`] when `C` is
+    /// [`u8`]).
+    ///
+    /// An identifier is defined as an ASCII alphabetic character or an underscore followed by any number of alphanumeric
+    /// characters or underscores. The regex pattern for it is `[a-zA-Z_][a-zA-Z0-9_]*`.
+    #[must_use]
+    pub fn ident<'a, I: ValueInput<'a> + StrInput<'a, C>, C: Char, E: ParserExtra<'a, I>>(
+    ) -> impl Parser<'a, I, &'a C::Str, E> + Copy + Clone {
+        any()
+            // Use try_map over filter to get a better error on failure
+            .try_map(|c: C, span| {
+                if c.to_char().is_ascii_alphabetic() || c.to_char() == '_' {
+                    Ok(c)
+                } else {
+                    Err(Error::expected_found([], Some(MaybeRef::Val(c)), span))
+                }
+            })
+            .then(
+                any()
+                    // This error never appears due to `repeated` so can use `filter`
+                    .filter(|c: &C| c.to_char().is_ascii_alphanumeric() || c.to_char() == '_')
+                    .repeated(),
+            )
+            .slice()
+    }
+
+    /// Like [`ident`], but only accepts a specific identifier while rejecting trailing identifier characters.
+    ///
+    /// The output type of this parser is `I::Slice` (i.e: [`&str`] when `I` is [`&str`], and [`&[u8]`]
+    /// when `I::Slice` is [`&[u8]`]).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chumsky::prelude::*;
+    /// let def = text::keyword::<_, _, _, extra::Err<Simple<char>>>("def");
+    ///
+    /// // Exactly 'def' was found
+    /// assert_eq!(def.parse("def").into_result(), Ok("def"));
+    /// // Exactly 'def' was found, with non-identifier trailing characters
+    /// // This works because we made the parser lazy: it parses 'def' and ignores the rest
+    /// assert_eq!(def.clone().lazy().parse("def(foo, bar)").into_result(), Ok("def"));
+    /// // 'def' was found, but only as part of a larger identifier, so this fails to parse
+    /// assert!(def.lazy().parse("define").has_errors());
+    /// ```
+    #[track_caller]
+    pub fn keyword<
+        'a,
+        I: ValueInput<'a> + StrInput<'a, C>,
+        C: Char + 'a,
+        Str: AsRef<C::Str> + 'a + Clone,
+        E: ParserExtra<'a, I> + 'a,
+    >(
+        keyword: Str,
+    ) -> impl Parser<'a, I, &'a C::Str, E> + Clone + 'a
+    where
+        C::Str: PartialEq,
+    {
+        #[cfg(debug_assertions)]
+        {
+            let mut cs = C::str_to_chars(keyword.as_ref());
+            if let Some(c) = cs.next() {
+                assert!(c.to_char().is_ascii_alphabetic() || c.to_char() == '_', "The first character of a keyword must be ASCII alphabetic or an underscore, not {:?}", c);
             } else {
-                Err(Error::expected_found([], Some(MaybeRef::Val(c)), span))
+                panic!("Keyword must have at least one character");
             }
-        })
-        .then(
-            any()
-                // This error never appears due to `repeated` so can use `filter`
-                .filter(|c: &C| c.is_ident_continue())
-                .repeated(),
-        )
-        .slice()
+            for c in cs {
+                assert!(c.to_char().is_ascii_alphanumeric() || c.to_char() == '_', "Trailing characters of a keyword must be ASCII alphanumeric or an underscore, not {:?}", c);
+            }
+        }
+        ident()
+            .try_map(move |s: &C::Str, span| {
+                if s == keyword.as_ref() {
+                    Ok(())
+                } else {
+                    Err(Error::expected_found(None, None, span))
+                }
+            })
+            .slice()
+    }
 }
 
-/// A parser that accepts a C-style identifier.
-///
-/// The output type of this parser is [`Char::Str`] (i.e: [`&str`] when `C` is [`char`], and [`&[u8]`] when `C` is
-/// [`u8`]).
-///
-/// An identifier is defined as an ASCII alphabetic character or an underscore followed by any number of alphanumeric
-/// characters or underscores. The regex pattern for it is `[a-zA-Z_][a-zA-Z0-9_]*`.
-#[must_use]
-#[cfg(not(feature = "unicode"))]
-pub fn ident<'a, I: ValueInput<'a> + StrInput<'a, C>, C: Char, E: ParserExtra<'a, I>>(
-) -> impl Parser<'a, I, &'a C::Str, E> + Copy + Clone {
-    any()
-        // Use try_map over filter to get a better error on failure
-        .try_map(|c: C, span| {
-            if c.to_char().is_ascii_alphabetic() || c.to_char() == '_' {
-                Ok(c)
+/// Parsers and utilities for working with unicode inputs.
+pub mod unicode {
+    use super::*;
+
+    /// A parser that accepts an identifier.
+    ///
+    /// The output type of this parser is [`Char::Str`] (i.e: [`&str`] when `C` is [`char`], and [`&[u8]`] when `C` is
+    /// [`u8`]).
+    ///
+    /// An identifier is defined as per "Default Identifiers" in [Unicode Standard Annex #31](https://www.unicode.org/reports/tr31/).
+    #[must_use]
+    pub fn ident<'a, I: ValueInput<'a> + StrInput<'a, C>, C: Char, E: ParserExtra<'a, I>>(
+    ) -> impl Parser<'a, I, &'a C::Str, E> + Copy + Clone {
+        any()
+            // Use try_map over filter to get a better error on failure
+            .try_map(|c: C, span| {
+                if c.is_ident_start() {
+                    Ok(c)
+                } else {
+                    Err(Error::expected_found([], Some(MaybeRef::Val(c)), span))
+                }
+            })
+            .then(
+                any()
+                    // This error never appears due to `repeated` so can use `filter`
+                    .filter(|c: &C| c.is_ident_continue())
+                    .repeated(),
+            )
+            .slice()
+    }
+
+    /// Like [`ident`], but only accepts a specific identifier while rejecting trailing identifier characters.
+    ///
+    /// The output type of this parser is `I::Slice` (i.e: [`&str`] when `I` is [`&str`], and [`&[u8]`]
+    /// when `I::Slice` is [`&[u8]`]).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chumsky::prelude::*;
+    /// let def = text::keyword::<_, _, _, extra::Err<Simple<char>>>("def");
+    ///
+    /// // Exactly 'def' was found
+    /// assert_eq!(def.parse("def").into_result(), Ok("def"));
+    /// // Exactly 'def' was found, with non-identifier trailing characters
+    /// // This works because we made the parser lazy: it parses 'def' and ignores the rest
+    /// assert_eq!(def.clone().lazy().parse("def(foo, bar)").into_result(), Ok("def"));
+    /// // 'def' was found, but only as part of a larger identifier, so this fails to parse
+    /// assert!(def.lazy().parse("define").has_errors());
+    /// ```
+    #[track_caller]
+    pub fn keyword<
+        'a,
+        I: ValueInput<'a> + StrInput<'a, C>,
+        C: Char + 'a,
+        Str: AsRef<C::Str> + 'a + Clone,
+        E: ParserExtra<'a, I> + 'a,
+    >(
+        keyword: Str,
+    ) -> impl Parser<'a, I, &'a C::Str, E> + Clone + 'a
+    where
+        C::Str: PartialEq,
+    {
+        #[cfg(debug_assertions)]
+        {
+            let mut cs = C::str_to_chars(keyword.as_ref());
+            if let Some(c) = cs.next() {
+                assert!(c.is_ident_start(), "The first character of a keyword must be a valid unicode XID_START, not {:?}", c);
             } else {
-                Err(Error::expected_found([], Some(MaybeRef::Val(c)), span))
+                panic!("Keyword must have at least one character");
             }
-        })
-        .then(
-            any()
-                // This error never appears due to `repeated` so can use `filter`
-                .filter(|c: &C| c.to_char().is_ascii_alphanumeric() || c.to_char() == '_')
-                .repeated(),
-        )
-        .slice()
+            for c in cs {
+                assert!(c.is_ident_continue(), "Trailing characters of a keyword must be valid as unicode XID_CONTINUE, not {:?}", c);
+            }
+        }
+        ident()
+            .try_map(move |s: &C::Str, span| {
+                if s == keyword.as_ref() {
+                    Ok(())
+                } else {
+                    Err(Error::expected_found(None, None, span))
+                }
+            })
+            .slice()
+    }
 }
 
 // TODO: Better native form of semantic indentation that uses the context system?
-
-/// Like [`ident`], but only accepts a specific identifier while rejecting trailing identifier characters.
-///
-/// The output type of this parser is `I::Slice` (i.e: [`&str`] when `I` is [`&str`], and [`&[u8]`]
-/// when `I::Slice` is [`&[u8]`]).
-///
-/// # Examples
-///
-/// ```
-/// # use chumsky::prelude::*;
-/// let def = text::keyword::<_, _, _, extra::Err<Simple<char>>>("def");
-///
-/// // Exactly 'def' was found
-/// assert_eq!(def.parse("def").into_result(), Ok("def"));
-/// // Exactly 'def' was found, with non-identifier trailing characters
-/// // This works because we made the parser lazy: it parses 'def' and ignores the rest
-/// assert_eq!(def.clone().lazy().parse("def(foo, bar)").into_result(), Ok("def"));
-/// // 'def' was found, but only as part of a larger identifier, so this fails to parse
-/// assert!(def.lazy().parse("define").has_errors());
-/// ```
-#[track_caller]
-pub fn keyword<
-    'a,
-    I: ValueInput<'a> + StrInput<'a, C>,
-    C: Char + 'a,
-    Str: AsRef<C::Str> + 'a + Clone,
-    E: ParserExtra<'a, I> + 'a,
->(
-    keyword: Str,
-) -> impl Parser<'a, I, &'a C::Str, E> + Clone + 'a
-where
-    C::Str: PartialEq,
-{
-    #[cfg(debug_assertions)]
-    {
-        let mut cs = C::str_to_chars(keyword.as_ref());
-        if let Some(c) = cs.next() {
-            assert!(c.to_char().is_ascii_alphabetic() || c.to_char() == '_', "The first character of a keyword must be ASCII alphabetic or an underscore, not {:?}", c);
-        } else {
-            panic!("Keyword must have at least one character");
-        }
-        for c in cs {
-            assert!(c.to_char().is_ascii_alphanumeric() || c.to_char() == '_', "Trailing characters of a keyword must be ASCII alphanumeric or an underscore, not {:?}", c);
-        }
-    }
-    ident()
-        .try_map(move |s: &C::Str, span| {
-            if s == keyword.as_ref() {
-                Ok(())
-            } else {
-                Err(Error::expected_found(None, None, span))
-            }
-        })
-        .slice()
-}
 
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
 
-    fn make_kw_parser<'a, C: text::Char, I: crate::StrInput<'a, C>>(
+    fn make_ascii_kw_parser<'a, C: text::Char, I: crate::StrInput<'a, C>>(
         s: &'a C::Str,
     ) -> impl Parser<'a, I, ()>
     where
         C::Str: PartialEq,
     {
-        text::keyword(s).ignored()
+        text::ascii::keyword(s).ignored()
+    }
+
+    fn make_unicode_kw_parser<'a, C: text::Char, I: crate::StrInput<'a, C>>(
+        s: &'a C::Str,
+    ) -> impl Parser<'a, I, ()>
+    where
+        C::Str: PartialEq,
+    {
+        text::unicode::keyword(s).ignored()
     }
 
     #[test]
     fn keyword_good() {
-        make_kw_parser::<char, &str>("hello");
-        make_kw_parser::<char, &str>("_42");
+        make_ascii_kw_parser::<char, &str>("hello");
+        make_ascii_kw_parser::<char, &str>("_42");
+
+        make_unicode_kw_parser::<char, &str>("שלום");
+        make_unicode_kw_parser::<char, &str>("привет");
+        make_unicode_kw_parser::<char, &str>("你好");
     }
 
     #[test]
     #[should_panic]
     fn keyword_numeric() {
-        make_kw_parser::<char, &str>("42");
+        make_ascii_kw_parser::<char, &str>("42");
     }
 
     #[test]
     #[should_panic]
     fn keyword_empty() {
-        make_kw_parser::<char, &str>("");
+        make_ascii_kw_parser::<char, &str>("");
     }
 
     #[test]
     #[should_panic]
     fn keyword_not_alphanum() {
-        make_kw_parser::<char, &str>("hi\n");
+        make_ascii_kw_parser::<char, &str>("hi\n");
+    }
+
+    #[test]
+    #[should_panic]
+    fn keyword_unicode_in_ascii() {
+        make_ascii_kw_parser::<char, &str>("שלום");
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -46,6 +46,14 @@ pub trait Char: Sized + Copy + PartialEq + fmt::Debug + Sealed + 'static {
     /// Returns true if the character is canonically considered to be a numeric digit.
     fn is_digit(&self, radix: u32) -> bool;
 
+    #[cfg(feature = "unicode")]
+    /// Returns true if the character is canonically considered to be valid for starting an identifier.
+    fn is_ident_start(&self) -> bool;
+
+    #[cfg(feature = "unicode")]
+    /// Returns true if the character is canonically considered to be a valid within an identifier.
+    fn is_ident_continue(&self) -> bool;
+
     /// Returns this character as a [`char`].
     fn to_char(&self) -> char;
 
@@ -99,6 +107,16 @@ impl Char for char {
     fn str_to_chars(s: &Self::Str) -> Self::StrCharIter<'_> {
         s.chars()
     }
+
+    #[cfg(feature = "unicode")]
+    fn is_ident_start(&self) -> bool {
+        unicode_ident::is_xid_start(*self)
+    }
+
+    #[cfg(feature = "unicode")]
+    fn is_ident_continue(&self) -> bool {
+        unicode_ident::is_xid_continue(*self)
+    }
 }
 
 impl Sealed for u8 {}
@@ -134,7 +152,7 @@ impl Char for u8 {
         b'0'
     }
     fn is_digit(&self, radix: u32) -> bool {
-        (*self as char).is_digit(radix)
+        self.to_char().is_digit(radix)
     }
     fn to_char(&self) -> char {
         *self as char
@@ -143,6 +161,16 @@ impl Char for u8 {
     type StrCharIter<'a> = core::iter::Copied<core::slice::Iter<'a, u8>>;
     fn str_to_chars(s: &Self::Str) -> Self::StrCharIter<'_> {
         s.iter().copied()
+    }
+
+    #[cfg(feature = "unicode")]
+    fn is_ident_start(&self) -> bool {
+        self.to_char().is_ascii_alphabetic() || self.to_char() == '_'
+    }
+
+    #[cfg(feature = "unicode")]
+    fn is_ident_continue(&self) -> bool {
+        self.to_char().is_ascii_alphanumeric() || self.to_char() == '_'
     }
 }
 
@@ -371,6 +399,34 @@ pub fn int<'a, I: ValueInput<'a> + StrInput<'a, C>, C: Char, E: ParserExtra<'a, 
         .slice()
 }
 
+/// A parser that accepts an identifier.
+///
+/// The output type of this parser is [`Char::Str`] (i.e: [`&str`] when `C` is [`char`], and [`&[u8]`] when `C` is
+/// [`u8`]).
+///
+/// An identifier is defined as per "Default Identifiers" in [Unicode Standard Annex #31](https://www.unicode.org/reports/tr31/).
+#[must_use]
+#[cfg(feature = "unicode")]
+pub fn ident<'a, I: ValueInput<'a> + StrInput<'a, C>, C: Char, E: ParserExtra<'a, I>>(
+) -> impl Parser<'a, I, &'a C::Str, E> + Copy + Clone {
+    any()
+        // Use try_map over filter to get a better error on failure
+        .try_map(|c: C, span| {
+            if c.is_ident_start() {
+                Ok(c)
+            } else {
+                Err(Error::expected_found([], Some(MaybeRef::Val(c)), span))
+            }
+        })
+        .then(
+            any()
+                // This error never appears due to `repeated` so can use `filter`
+                .filter(|c: &C| c.is_ident_continue())
+                .repeated(),
+        )
+        .slice()
+}
+
 /// A parser that accepts a C-style identifier.
 ///
 /// The output type of this parser is [`Char::Str`] (i.e: [`&str`] when `C` is [`char`], and [`&[u8]`] when `C` is
@@ -379,6 +435,7 @@ pub fn int<'a, I: ValueInput<'a> + StrInput<'a, C>, C: Char, E: ParserExtra<'a, 
 /// An identifier is defined as an ASCII alphabetic character or an underscore followed by any number of alphanumeric
 /// characters or underscores. The regex pattern for it is `[a-zA-Z_][a-zA-Z0-9_]*`.
 #[must_use]
+#[cfg(not(feature = "unicode"))]
 pub fn ident<'a, I: ValueInput<'a> + StrInput<'a, C>, C: Char, E: ParserExtra<'a, I>>(
 ) -> impl Parser<'a, I, &'a C::Str, E> + Copy + Clone {
     any()

--- a/src/text.rs
+++ b/src/text.rs
@@ -548,7 +548,11 @@ pub mod unicode {
         {
             let mut cs = C::str_to_chars(keyword.as_ref());
             if let Some(c) = cs.next() {
-                assert!(c.is_ident_start(), "The first character of a keyword must be a valid unicode XID_START, not {:?}", c);
+                assert!(
+                    c.is_ident_start(),
+                    "The first character of a keyword must be a valid unicode XID_START, not {:?}",
+                    c
+                );
             } else {
                 panic!("Keyword must have at least one character");
             }

--- a/tutorial.md
+++ b/tutorial.md
@@ -576,7 +576,7 @@ let expr = recursive(|expr| {
 });
 
 let decl = recursive(|decl| {
-    let r#let = text::keyword("let")
+    let r#let = text::ascii::keyword("let")
         .ignore_then(ident)
         .then_ignore(just('='))
         .then(expr.clone())
@@ -685,7 +685,7 @@ looks very much like the existing definition of `r#let`:
 
 ```rust
 let decl = recursive(|decl| {
-    let r#let = text::keyword("let")
+    let r#let = text::ascii::keyword("let")
         .ignore_then(ident)
         .then_ignore(just('='))
         .then(expr.clone())
@@ -697,7 +697,7 @@ let decl = recursive(|decl| {
             then: Box::new(then),
         });
 
-    let r#fn = text::keyword("fn")
+    let r#fn = text::ascii::keyword("fn")
         .ignore_then(ident)
         .then(ident.repeated())
         .then_ignore(just('='))

--- a/tutorial.md
+++ b/tutorial.md
@@ -539,7 +539,7 @@ expression definition. However, we also want to be able to chain `let`s together
 definition. We call it `decl` ('declaration') because we're eventually going to be adding `fn` syntax too.
 
 ```rust
-let ident = text::ident()
+let ident = text::ascii::ident()
     .padded();
 
 let expr = recursive(|expr| {


### PR DESCRIPTION
Fixes #413.

I gated this behind a feature called `unicode` so that it will be opt-in, including the dependency on `unicode-ident`. For now, I didn't enable the feature by default, so it won't be a breaking change.