### PR TITLE
Fix JSON example

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -73,7 +73,7 @@ fn parser<'a>() -> impl Parser<'a, &'a str, Json, extra::Err<Rich<'a, char>>> {
             .clone()
             .separated_by(just(',').padded().recover_with(skip_then_retry_until(
                 any().ignored(),
-                one_of(",").ignored(),
+                one_of(",]").ignored(),
             )))
             .allow_trailing()
             .collect()
@@ -92,7 +92,7 @@ fn parser<'a>() -> impl Parser<'a, &'a str, Json, extra::Err<Rich<'a, char>>> {
             .clone()
             .separated_by(just(',').padded().recover_with(skip_then_retry_until(
                 any().ignored(),
-                one_of(",").ignored(),
+                one_of(",}").ignored(),
             )))
             .collect()
             .padded()


### PR DESCRIPTION
The current json example produces incorrect error reports after objects and arrays, and in some cases causes valid objects to not be included in the result. This PR should fix that, altough, tbh I only just started looking at chumsky today so this might not be the best way to solve it(?)

Examples of json that produces incorrect errors prior to this change:

```json
{
    "A": {
        "B": 123
    },
    "C": {
        "D": 456
    },
    "E": [
        "F"
    ],
    "G": "done"
}
```

```json
{
    "A": {
        "B": "123",
        "C": [1,2,3],
        "D": 123
    }    
}
```

![bild](https://github.com/zesterer/chumsky/assets/5273471/45630fb2-4d7a-4e97-b260-eb97c2ebed3a)
![bild](https://github.com/zesterer/chumsky/assets/5273471/d6acd751-d6db-4e52-ac62-bc574131ad22)






