### PR TITLE
Add SimpleSpan::splat

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -66,6 +66,11 @@ impl<T> SimpleSpan<T> {
         }
     }
 
+    /// Create a new `SimpleSpan` from a single offset, useful for an EOI (End Of Input) span.
+    pub fn splat(offset: T) -> SimpleSPan<T> {
+        Self::new(offset, offset)
+    }
+    
     /// Convert this span into a [`std::ops::Range`].
     pub fn into_range(self) -> Range<T> {
         self.into()

--- a/src/span.rs
+++ b/src/span.rs
@@ -71,7 +71,7 @@ impl<T> SimpleSpan<T> {
     where
         T: Clone 
     {
-        Self::new(offset, offset)
+        Self::new(offset, offset.clone())
     }
     
     /// Convert this span into a [`std::ops::Range`].

--- a/src/span.rs
+++ b/src/span.rs
@@ -67,7 +67,10 @@ impl<T> SimpleSpan<T> {
     }
 
     /// Create a new `SimpleSpan` from a single offset, useful for an EOI (End Of Input) span.
-    pub fn splat(offset: T) -> SimpleSpan<T> {
+    pub fn splat(offset: T) -> SimpleSpan<T> 
+    where
+        T: Clone 
+    {
         Self::new(offset, offset)
     }
     

--- a/src/span.rs
+++ b/src/span.rs
@@ -67,7 +67,7 @@ impl<T> SimpleSpan<T> {
     }
 
     /// Create a new `SimpleSpan` from a single offset, useful for an EOI (End Of Input) span.
-    pub fn splat(offset: T) -> SimpleSPan<T> {
+    pub fn splat(offset: T) -> SimpleSpan<T> {
         Self::new(offset, offset)
     }
     


### PR DESCRIPTION
SimpleSpan::splat creates a SimpleSpan from a single offset using it as both the start and end. This is more convenient for making an EOI span than passing the same argument twice into SimpleSpan::new.