### PR TITLE
memo-name: correct inconsistent spelling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ nightly = []
 # Allows deeper recursion by dynamically spilling stack state on to the heap.
 spill-stack = ["stacker", "std"]
 
-# Allows parser memoisation, speeding up heavily back-tracking parsers and allowing left recursion.
+# Allows parser memoization, speeding up heavily back-tracking parsers and allowing left recursion.
 memoization = []
 
 # Allows extending chumsky by writing your own parser implementations.

--- a/guide/meet_the_parsers.md
+++ b/guide/meet_the_parsers.md
@@ -120,7 +120,7 @@ Miscellaneous combinators and those that relate to error recovery.
 |---------------------------------|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [`Parser::boxed`]               | `a.boxed()`                           | Performs type-erasure on a parser, allocating it on the heap. Stategically boxing of parsers can improve compilation times and allows dynamically building up parsers at runtime.       |
 | [`Parser::recover_with`]        | `a.recover_with(r)`                   | Attempt to parse a pattern. On failure, the given recovery strategy is used to attempt to recovery from the error. See the documentation for more information.                          |
-| [`Parser::memoised`]            | `a.memoised()`                        | Parse a pattern, but remember whether it succeeded or failed and reuse that information when parsing the same input again. Allows expressing left-recursive or exponential patterns.    |
+| [`Parser::memoized`]            | `a.memoized()`                        | Parse a pattern, but remember whether it succeeded or failed and reuse that information when parsing the same input again. Allows expressing left-recursive or exponential patterns.    |
 
 ### Backtracking and input manipulation
 

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -762,15 +762,15 @@ where
     go_extra!(O);
 }
 
-/// See [`Parser::memoised`].
+/// See [`Parser::memoized`].
 #[cfg(feature = "memoization")]
 #[derive(Copy, Clone)]
-pub struct Memoised<A> {
+pub struct Memoized<A> {
     pub(crate) parser: A,
 }
 
 #[cfg(feature = "memoization")]
-impl<'a, I, E, A, O> ParserSealed<'a, I, O, E> for Memoised<A>
+impl<'a, I, E, A, O> ParserSealed<'a, I, O, E> for Memoized<A>
 where
     I: Input<'a>,
     E: ParserExtra<'a, I>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -720,22 +720,22 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
         }
     }
 
-    /// Memoise the parser such that later attempts to parse the same input 'remember' the attempt and exit early.
+    /// Memoize the parser such that later attempts to parse the same input 'remember' the attempt and exit early.
     ///
     /// If you're finding that certain inputs produce exponential behaviour in your parser, strategically applying
-    /// memoisation to a ['garden path'](https://en.wikipedia.org/wiki/Garden-path_sentence) rule is often an effective
-    /// way to solve the problem. At the limit, applying memoisation to all combinators will turn any parser into one
+    /// memoization to a ['garden path'](https://en.wikipedia.org/wiki/Garden-path_sentence) rule is often an effective
+    /// way to solve the problem. At the limit, applying memoization to all combinators will turn any parser into one
     /// with `O(n)`, albeit with very significant per-element overhead and high memory usage.
     ///
-    /// Memoisation also works with recursion, so this can be used to write parsers using
+    /// Memoization also works with recursion, so this can be used to write parsers using
     /// [left recursion](https://en.wikipedia.org/wiki/Left_recursion).
     // TODO: Example
     #[cfg(feature = "memoization")]
-    fn memoised(self) -> Memoised<Self>
+    fn memoized(self) -> Memoized<Self>
     where
         Self: Sized,
     {
-        Memoised { parser: self }
+        Memoized { parser: self }
     }
 
     /// Transform all outputs of this parser to a pretermined value.
@@ -2779,7 +2779,7 @@ mod tests {
                     .then_ignore(just('+'))
                     .then(atom.clone())
                     .map(|(a, b)| format!("{}{}", a, b))
-                    .memoised()
+                    .memoized()
                     .or(atom)
             })
             .then_ignore(end())
@@ -2809,7 +2809,7 @@ mod tests {
                     .then_ignore(just('+'))
                     .then(expr)
                     .map(|(a, b)| format!("{}{}", a, b))
-                    .memoised();
+                    .memoized();
 
                 sum.or(atom)
             })


### PR DESCRIPTION
Addresses #444 by moving everything to the American-English 'z' instead of 's'.

I suppose this technically is a breaking change, because `Memoise` was public, but eh.