### PR TITLE
Fixes for lexical-numbers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub mod util;
 /// cereal.”*
 pub mod prelude {
     #[cfg(feature = "lexical-numbers")]
-    pub use super::number::number;
+    pub use super::number::{self, number};
     #[cfg(feature = "regex")]
     pub use super::regex::regex;
     pub use super::{

--- a/src/number.rs
+++ b/src/number.rs
@@ -11,11 +11,20 @@ use lexical::parse_partial;
 use lexical::FromLexical;
 
 /// TODO: Add documentation when approved
-#[derive(Clone, Copy)]
 pub struct Number<const F: u128, I, O, E> {
     #[allow(dead_code)]
     phantom: EmptyPhantom<(I, E, O)>,
 }
+
+impl<const F: u128, I, O, E> Clone for Number<F, I, O, E> {
+    fn clone(&self) -> Self {
+        Self {
+            phantom: EmptyPhantom::new(),
+        }
+    }
+}
+
+impl<const F: u128, I, O, E> Copy for Number<F, I, O, E> {}
 
 /// TODO: Add documentation when approved
 pub const fn number<const F: u128, I, O, E>() -> Number<F, I, O, E> {


### PR DESCRIPTION
Hey, this is just a quick PR to implement a QoL fix, and an implementation fix:
* `Number` should always be copyable
* reexport both `number` function and `number` module

I also took the time to update the example for showcasing in the related issue #398 