### PR TITLE
Swap to regex-automata and significantly improve regex performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ lexical-numbers = ["lexical", "unstable"]
 # Adds impl of Parser for either::Either
 either = ["dep:either"]
 
+# Enables regex combinators
+regex = ["dep:regex-automata"]
+
 # An alias of all features that work with the stable compiler.
 # Do not use this feature, its removal is not considered a breaking change and its behaviour may change.
 # If you're working on chumsky and you're adding a feature that does not require nightly support, please add it to this list.
@@ -59,14 +62,13 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-hashbrown = "0.13"
+hashbrown = "0.14"
 stacker = { version = "0.1", optional = true }
-# Enables regex combinators
-regex = { version = "1.7", optional = true }
+regex-automata = { version = "0.3", optional = true }
 spin = { version = "0.9", features = ["once"], default-features = false, optional = true }
 lexical = { version = "6.1.1", default-features = false, features = ["parse-integers", "parse-floats", "format"], optional = true }
 either = { version = "1.8.1", optional = true }
-unicode-ident =  "1.0.9"
+unicode-ident =  "1.0.10"
 
 [dev-dependencies]
 ariadne = "0.2"

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -248,68 +248,56 @@ fn bench_regex(c: &mut Criterion) {
     let re_foo = regex::<_, _, extra::Default>("foo");
     let re_foo2 = regex::<_, _, extra::Default>("[fF]oo");
     let re_rep = regex::<_, _, extra::Default>("(?:abc){4}");
-    
+
     let mut group = c.benchmark_group("regex");
-    
-    group.bench_function(BenchmarkId::new("foo", "foo"),
-        |b| {
-            b.iter(|| {
-                black_box(re_foo.parse(black_box("foo")))
-                    .into_result()
-                    .unwrap();
-            })
-        }
-    );
 
-    group.bench_function(BenchmarkId::new("foo", "barfoofoofoo"),
-         |b| {
-             b.iter(|| {
-                 black_box(re_foo.parse(black_box("barfoofoofoo")))
-                     .into_result()
-                     .unwrap_err();
-             })
-         }
-    );
-    
-    group.bench_function(BenchmarkId::new("[fF]oo", "foo"),
-        |b| {
-            b.iter(|| {
-                black_box(re_foo2.parse(black_box("foo")))
-                    .into_result()
-                    .unwrap()
-            })
-        }
-    );
+    group.bench_function(BenchmarkId::new("foo", "foo"), |b| {
+        b.iter(|| {
+            black_box(re_foo.parse(black_box("foo")))
+                .into_result()
+                .unwrap();
+        })
+    });
 
-    group.bench_function(BenchmarkId::new("[fF]oo", "Foo"),
-         |b| {
-             b.iter(|| {
-                 black_box(re_foo2.parse(black_box("Foo")))
-                     .into_result()
-                     .unwrap()
-             })
-         }
-    );
+    group.bench_function(BenchmarkId::new("foo", "barfoofoofoo"), |b| {
+        b.iter(|| {
+            black_box(re_foo.parse(black_box("barfoofoofoo")))
+                .into_result()
+                .unwrap_err();
+        })
+    });
 
-    group.bench_function(BenchmarkId::new("[fF]oo", "barFoofoo"),
-         |b| {
-             b.iter(|| {
-                 black_box(re_foo2.parse(black_box("barFoofoo")))
-                     .into_result()
-                     .unwrap_err()
-             })
-         }
-    );
+    group.bench_function(BenchmarkId::new("[fF]oo", "foo"), |b| {
+        b.iter(|| {
+            black_box(re_foo2.parse(black_box("foo")))
+                .into_result()
+                .unwrap()
+        })
+    });
 
-    group.bench_function(BenchmarkId::new("(?:abc){4}", "abcabcabcabc"),
-         |b| {
-             b.iter(|| {
-                 black_box(re_rep.parse(black_box("abcabcabcabc")))
-                     .into_result()
-                     .unwrap()
-             })
-         }
-    );
+    group.bench_function(BenchmarkId::new("[fF]oo", "Foo"), |b| {
+        b.iter(|| {
+            black_box(re_foo2.parse(black_box("Foo")))
+                .into_result()
+                .unwrap()
+        })
+    });
+
+    group.bench_function(BenchmarkId::new("[fF]oo", "barFoofoo"), |b| {
+        b.iter(|| {
+            black_box(re_foo2.parse(black_box("barFoofoo")))
+                .into_result()
+                .unwrap_err()
+        })
+    });
+
+    group.bench_function(BenchmarkId::new("(?:abc){4}", "abcabcabcabc"), |b| {
+        b.iter(|| {
+            black_box(re_rep.parse(black_box("abcabcabcabc")))
+                .into_result()
+                .unwrap()
+        })
+    });
 }
 
 #[cfg(not(feature = "regex"))]

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -243,9 +243,81 @@ fn bench_then(c: &mut Criterion) {
     });
 }
 
+#[cfg(feature = "regex")]
+fn bench_regex(c: &mut Criterion) {
+    let re_foo = regex::<_, _, extra::Default>("foo");
+    let re_foo2 = regex::<_, _, extra::Default>("[fF]oo");
+    let re_rep = regex::<_, _, extra::Default>("(?:abc){4}");
+    
+    let mut group = c.benchmark_group("regex");
+    
+    group.bench_function(BenchmarkId::new("foo", "foo"),
+        |b| {
+            b.iter(|| {
+                black_box(re_foo.parse(black_box("foo")))
+                    .into_result()
+                    .unwrap();
+            })
+        }
+    );
+
+    group.bench_function(BenchmarkId::new("foo", "barfoofoofoo"),
+         |b| {
+             b.iter(|| {
+                 black_box(re_foo.parse(black_box("barfoofoofoo")))
+                     .into_result()
+                     .unwrap_err();
+             })
+         }
+    );
+    
+    group.bench_function(BenchmarkId::new("[fF]oo", "foo"),
+        |b| {
+            b.iter(|| {
+                black_box(re_foo2.parse(black_box("foo")))
+                    .into_result()
+                    .unwrap()
+            })
+        }
+    );
+
+    group.bench_function(BenchmarkId::new("[fF]oo", "Foo"),
+         |b| {
+             b.iter(|| {
+                 black_box(re_foo2.parse(black_box("Foo")))
+                     .into_result()
+                     .unwrap()
+             })
+         }
+    );
+
+    group.bench_function(BenchmarkId::new("[fF]oo", "barFoofoo"),
+         |b| {
+             b.iter(|| {
+                 black_box(re_foo2.parse(black_box("barFoofoo")))
+                     .into_result()
+                     .unwrap_err()
+             })
+         }
+    );
+
+    group.bench_function(BenchmarkId::new("(?:abc){4}", "abcabcabcabc"),
+         |b| {
+             b.iter(|| {
+                 black_box(re_rep.parse(black_box("abcabcabcabc")))
+                     .into_result()
+                     .unwrap()
+             })
+         }
+    );
+}
+
+#[cfg(not(feature = "regex"))]
+fn bench_regex(_: &mut Criterion) {}
+
 criterion_group!(
     name = benches;
     config = utils::make_criterion();
-    targets = bench_choice, bench_or, bench_group, bench_then,
+    targets = bench_choice, bench_or, bench_group, bench_then, bench_regex,
 );
 criterion_main!(benches);

--- a/src/input.rs
+++ b/src/input.rs
@@ -148,7 +148,7 @@ pub trait ExactSizeInput<'a>: Input<'a> {
 pub trait SliceInput<'a>: ExactSizeInput<'a> {
     /// The unsized slice type of this input. For [`&str`] it's `&str`, and for [`&[T]`] it will be `&[T]`.
     type Slice;
-    
+
     /// Get the full slice of the input
     #[doc(hidden)]
     fn full_slice(&self) -> Self::Slice;
@@ -393,7 +393,7 @@ impl<'a, T: 'a, const N: usize> SliceInput<'a> for &'a [T; N] {
     fn full_slice(&self) -> Self::Slice {
         *self
     }
-    
+
     #[inline(always)]
     fn slice(&self, range: Range<Self::Offset>) -> Self::Slice {
         &self[range]
@@ -1342,7 +1342,7 @@ impl<'a, 'parse, I: Input<'a>, E: ParserExtra<'a, I>> InputRef<'a, 'parse, I, E>
     {
         self.input.full_slice()
     }
-    
+
     /// Get a slice of the input that covers the given offset range.
     #[inline]
     pub fn slice(&self, range: Range<Offset<'a, 'parse, I>>) -> I::Slice
@@ -1377,6 +1377,15 @@ impl<'a, 'parse, I: Input<'a>, E: ParserExtra<'a, I>> InputRef<'a, 'parse, I, E>
         I: SliceInput<'a>,
     {
         self.input.slice_from(range)
+    }
+
+    #[cfg_attr(not(feature = "lexical-numbers"), allow(dead_code))]
+    #[inline(always)]
+    pub(crate) fn slice_trailing_inner(&self) -> I::Slice
+    where
+        I: SliceInput<'a>,
+    {
+        self.input.slice_from(self.offset..)
     }
 
     /// Get a span over the input that covers the given offset range.

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -36,15 +36,13 @@ where
     #[inline]
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, &'a C::Str> {
         let before = inp.offset();
-        
+
         let re_in = ReInput::new(inp.full_slice())
             .anchored(Anchored::Yes)
             .range(before.offset..);
-        
-        let res = self.regex
-            .find(re_in)
-            .map(|m| m.len());
-        
+
+        let res = self.regex.find(re_in).map(|m| m.len());
+
         match res {
             Some(len) => {
                 let before = inp.offset();

--- a/src/text.rs
+++ b/src/text.rs
@@ -18,18 +18,7 @@ pub trait Char: Sized + Copy + PartialEq + fmt::Debug + Sealed + 'static {
     /// The default unsized [`str`]-like type of a linear sequence of this character.
     ///
     /// For [`char`], this is [`str`]. For [`u8`], this is [`[u8]`].
-    type Str: ?Sized + AsRef<Self::Str> + 'static;
-
-    /// The type of a regex expression which can match on this type
-    #[cfg(feature = "regex")]
-    type Regex;
-
-    #[cfg(feature = "regex")]
-    #[doc(hidden)]
-    fn new_regex(pattern: &str) -> Self::Regex;
-    #[cfg(feature = "regex")]
-    #[doc(hidden)]
-    fn match_regex(regex: &Self::Regex, trailing: &Self::Str) -> Option<usize>;
+    type Str: ?Sized + AsRef<[u8]> + AsRef<Self::Str> + 'static;
 
     /// Convert the given ASCII character to this character type.
     fn from_ascii(c: u8) -> Self;
@@ -65,22 +54,6 @@ pub trait Char: Sized + Copy + PartialEq + fmt::Debug + Sealed + 'static {
 impl Sealed for char {}
 impl Char for char {
     type Str = str;
-
-    #[cfg(feature = "regex")]
-    type Regex = ::regex::Regex;
-
-    #[cfg(feature = "regex")]
-    fn new_regex(pattern: &str) -> Self::Regex {
-        ::regex::Regex::new(pattern).expect("Failed to compile regex")
-    }
-    #[cfg(feature = "regex")]
-    #[inline]
-    fn match_regex(regex: &Self::Regex, trailing: &Self::Str) -> Option<usize> {
-        regex
-            .find(trailing)
-            .filter(|m| m.start() == 0)
-            .map(|m| m.end())
-    }
 
     fn from_ascii(c: u8) -> Self {
         c as char
@@ -118,22 +91,6 @@ impl Char for char {
 impl Sealed for u8 {}
 impl Char for u8 {
     type Str = [u8];
-
-    #[cfg(feature = "regex")]
-    type Regex = ::regex::bytes::Regex;
-
-    #[cfg(feature = "regex")]
-    fn new_regex(pattern: &str) -> Self::Regex {
-        ::regex::bytes::Regex::new(pattern).expect("Failed to compile regex")
-    }
-    #[cfg(feature = "regex")]
-    #[inline]
-    fn match_regex(regex: &Self::Regex, trailing: &Self::Str) -> Option<usize> {
-        regex
-            .find(trailing)
-            .filter(|m| m.start() == 0)
-            .map(|m| m.end())
-    }
 
     fn from_ascii(c: u8) -> Self {
         c


### PR DESCRIPTION
Also makes lookaround and anchors work better - `^` no longer always matches, but instead literally matches starts of lines. While this removes all difference between bytes and not bytes, that shouldn't actually change any behavior - unicode mode is still enabled on bytes in the regex crate, so if anything, the distinction likely causes more confusion than it solves.

I'd like to expose some of the knobs regex-automata has to the user eventually - most pressingly, enabling/disabling unicode mode at the parser level - but I haven't found the best way to handle that. I'd like to not build the regex during parse-time, but to not do that, we'd instead have to rebuild it every time the user changed a setting, which seems a little unfortunate. On the other hand, since it happens at parser building time not parse time, I'd be willing to eat the hit if there isn't a better way.