### PR TITLE
foo-example: fix by adding 'padded'

### DIFF
--- a/examples/foo.rs
+++ b/examples/foo.rs
@@ -76,7 +76,7 @@ fn parser<'a>() -> impl Parser<'a, &'a str, Expr<'a>> {
             |lhs, (op, rhs)| op(Box::new(lhs), Box::new(rhs)),
         );
 
-        sum
+        sum.padded()
     });
 
     let decl = recursive(|decl| {


### PR DESCRIPTION
Fixes #491 by adding `padded` to `sum` which ensures that all expressions allow for trailing / leading whitespace