### PR TITLE
Added ability for map_ctx to change the type of the context

### DIFF
--- a/examples/foo.rs
+++ b/examples/foo.rs
@@ -31,8 +31,7 @@ fn parser<'a>() -> impl Parser<'a, &'a str, Expr<'a>> {
     let ident = text::ascii::ident().padded();
 
     let expr = recursive(|expr| {
-        let int = text::int(10)
-            .map(|s: &str| Expr::Num(s.parse().unwrap()));
+        let int = text::int(10).map(|s: &str| Expr::Num(s.parse().unwrap()));
 
         let call = ident
             .then(

--- a/src/input.rs
+++ b/src/input.rs
@@ -1059,14 +1059,14 @@ pub struct InputRef<'a, 'parse, I: Input<'a>, E: ParserExtra<'a, I>> {
 
 impl<'a, 'parse, I: Input<'a>, E: ParserExtra<'a, I>> InputRef<'a, 'parse, I, E> {
     #[inline]
-    pub(crate) fn with_ctx<'sub_parse, C, O>(
+    pub(crate) fn with_ctx<'sub_parse, EM, O>(
         &'sub_parse mut self,
-        new_ctx: &'sub_parse C,
-        f: impl FnOnce(&mut InputRef<'a, 'sub_parse, I, extra::Full<E::Error, E::State, C>>) -> O,
+        new_ctx: &'sub_parse EM::Context,
+        f: impl FnOnce(&mut InputRef<'a, 'sub_parse, I, EM>) -> O,
     ) -> O
     where
         'parse: 'sub_parse,
-        C: 'a,
+        EM: ParserExtra<'a, I, Error = E::Error, State = E::State>,
     {
         let mut new_inp = InputRef {
             input: self.input,


### PR DESCRIPTION
Adds the ability for `map_ctx` to map to a different type and includes a doc-test.
Closes #487.