### PR TITLE
Implement Ord for Offset struct

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -935,9 +935,21 @@ impl<'a, 'parse, I: Input<'a>> Clone for Offset<'a, 'parse, I> {
     }
 }
 
+impl<'a, 'parse, I: Input<'a>> Eq for Offset<'a, 'parse, I> {}
 impl<'a, 'parse, I: Input<'a>> PartialEq for Offset<'a, 'parse, I> {
     fn eq(&self, other: &Self) -> bool {
         self.offset == other.offset
+    }
+}
+
+impl<'a, 'parse, I: Input<'a>> PartialOrd for Offset<'a, 'parse, I> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl<'a, 'parse, I: Input<'a>> Ord for Offset<'a, 'parse, I> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.offset.cmp(&other.offset)
     }
 }
 


### PR DESCRIPTION
Was nice and straightforward, since the [underlying Offset](https://github.com/zesterer/chumsky/blob/f10e56b7eac878cbad98f71fd5485a21d44db226/src/input.rs#L36) is already required to be Ord.

See also https://github.com/zesterer/chumsky/issues/354#issuecomment-1694332577