### PR TITLE
enable using a tokenized input as a Stream input

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1033,7 +1033,6 @@ where
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn as_ref_at<'parse>(
         &'parse mut self,
         offset: I::Offset,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -105,6 +105,7 @@ where
     }
 }
 
+// TODO: impl BorrowInput!
 impl<'a, I: Iterator + 'a> ValueInput<'a> for Stream<I>
 where
     I::Item: Clone,


### PR DESCRIPTION
### Problem

I'm parsing a string into tokens with chumsky, and I would like to also use chumsky to parse those tokens into something else. While `select! { ... }` is intended to enable this, it assumes that the stream of tokens is produced externally to chumsky, as in the logos example: https://github.com/zesterer/chumsky/blob/56762fe5c965880066a068038a18b5ac07afd75c/examples/logos.rs#L130-L145

### Solution
- Expose `.parse_iter()` outside of `#[cfg(test)]` and use it to construct a `Stream` instance.
- Expose `.stream(input)` as a public method of `IterParser` to generate a stream of transformed input.