### PR TITLE
Only enable vergen on docsrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ regex = ["dep:regex-automata"]
 # Enable serde serialization support
 serde = ["dep:serde"]
 
+# Enable dependencies only needed for generation of documentation on docs.rs
+docsrs = ["dep:vergen"]
+
 # An alias of all features that work with the stable compiler.
 # Do not use this feature, its removal is not considered a breaking change and its behaviour may change.
 # If you're working on chumsky and you're adding a feature that does not require nightly support, please add it to this list.
@@ -94,7 +97,7 @@ lasso = "0.7"
 slotmap = "1.0"
 
 [build-dependencies]
-vergen = { version = "=8.1.1", features = ["git", "gitoxide"] }
+vergen = { version = "=8.1.1", optional = true, features = ["git", "gitoxide"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.11", features = ["flamegraph", "criterion"] }

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,20 @@
 use std::error::Error;
+#[cfg(feature = "docsrs")]
 use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn Error>> {
+    emit_git_metadata()?;
+    Ok(())
+}
+
+#[cfg(feature = "docsrs")]
+fn emit_git_metadata() -> Result<(), Box<dyn Error>> {
     // Emit the instructions
     EmitBuilder::builder().all_git().emit()?;
+    Ok(())
+}
+
+#[cfg(not(feature = "docsrs"))]
+fn emit_git_metadata() -> Result<(), Box<dyn Error>> {
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,22 @@
 extern crate alloc;
 extern crate core;
 
+#[cfg(feature = "docsrs")]
 macro_rules! blob_url_prefix {
     () => {
         concat!(
             "https://github.com/zesterer/chumsky/blob/",
             env!("VERGEN_GIT_SHA")
+        )
+    };
+}
+
+#[cfg(not(feature = "docsrs"))]
+macro_rules! blob_url_prefix {
+    () => {
+        concat!(
+            "https://github.com/zesterer/chumsky/blob/",
+            env!("CARGO_PKG_VERSION")
         )
     };
 }


### PR DESCRIPTION
Hopefully fixes #503 

I personally would prefer if rustdoc fully supported including example code in the documentation, but this is better than nothing for now.