### PR TITLE
Added MapExtra support to the pratt combinator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chumsky"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "ariadne",
  "ciborium",


### PR DESCRIPTION
Inspired by #552, this allows pratt folding functions to make use of `MapExtra`.