### PR TITLE
Add one_of_ref()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,8 @@ pub mod prelude {
         extra,
         input::Input,
         primitive::{
-            any, any_ref, choice, custom, empty, end, group, just, map_ctx, none_of, one_of, todo,
+            any, any_ref, choice, custom, empty, end, group, just, map_ctx, none_of, one_of,
+            one_of_ref, todo,
         },
         recovery::{nested_delimiters, skip_then_retry_until, skip_until, via_parser},
         recursive::{recursive, Recursive},


### PR DESCRIPTION
Works just like `one_of()` but for `BorrowInput` rather than `ValueInput`.

This is just like I did for [`any_ref`](https://github.com/zesterer/chumsky/pull/528), and needed for the same reason, that is, because `one_of` can't be used for `BorrowInput`, only `ValueInput`