### PR TITLE
Fix benches and examples and check them in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,11 +23,11 @@ jobs:
             toolchain: nightly
             components: rustfmt, clippy
       - name: Run cargo check (all features)
-        run: cargo check --tests --verbose --all-features
+        run: cargo check --benches --examples --tests --verbose --all-features
       - name: Run cargo check (no features)
-        run: cargo check --tests --verbose --no-default-features
+        run: cargo check --benches --examples --tests --verbose --no-default-features
       - name: Run cargo clippy
-        run: cargo clippy --verbose --all-features -- -D warnings
+        run: cargo clippy --benches --examples --tests --verbose --all-features -- -D warnings
       - name: Run cargo fmt
         run: cargo fmt --verbose --check
       - name: Run cargo doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,9 +2411,9 @@ checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"
 
 [[package]]
 name = "winnow"
-version = "0.5.11"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e461589e194280efaa97236b73623445efa195aa633fd7004f39805707a9d53"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ unicode-ident =  "1.0.10"
 ariadne = "0.2"
 pom = "3.2"
 nom = "7.1"
-winnow = "0.5.0"
+winnow = "0.5.19"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 ciborium = { version = "0.2" }
 criterion = "0.4.0"

--- a/benches/cbor.rs
+++ b/benches/cbor.rs
@@ -3,7 +3,7 @@ use std::hint::black_box;
 
 mod utils;
 
-static CBOR: &'static [u8] = include_bytes!("samples/sample.cbor");
+static CBOR: &[u8] = include_bytes!("samples/sample.cbor");
 
 fn bench_cbor(c: &mut Criterion) {
     // c.bench_function("cbor_nom", {
@@ -125,7 +125,8 @@ mod chumsky_zero_copy {
                     };
                     cfg.exactly(num)
                 }))
-                .map_slice(int_out);
+                .to_slice()
+                .map(int_out);
 
             let uint = read_int.map(CborZero::Int);
             let nint = read_int.map(|i| CborZero::Int(-1 - i));
@@ -134,14 +135,16 @@ mod chumsky_zero_copy {
                 any()
                     .repeated()
                     .configure(|cfg, ctx| cfg.exactly(*ctx as usize))
-                    .map_slice(CborZero::Bytes),
+                    .to_slice()
+                    .map(CborZero::Bytes),
             );
 
             let str = read_int.ignore_with_ctx(
                 any()
                     .repeated()
                     .configure(|cfg, ctx| cfg.exactly(*ctx as usize))
-                    .map_slice(|slice| CborZero::String(std::str::from_utf8(slice).unwrap())),
+                    .to_slice()
+                    .map(|slice| CborZero::String(std::str::from_utf8(slice).unwrap())),
             );
 
             let array = read_int.ignore_with_ctx(

--- a/examples/foo.rs
+++ b/examples/foo.rs
@@ -27,6 +27,7 @@ enum Expr<'a> {
     },
 }
 
+#[allow(clippy::let_and_return)]
 fn parser<'a>() -> impl Parser<'a, &'a str, Expr<'a>> {
     let ident = text::ascii::ident().padded();
 

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -21,12 +21,12 @@ fn parser<'a>() -> impl Parser<'a, &'a str, Json, extra::Err<Rich<'a, char>>> {
     recursive(|value| {
         let digits = text::digits(10).to_slice();
 
-        let frac = just('.').then(digits.clone());
+        let frac = just('.').then(digits);
 
         let exp = just('e')
             .or(just('E'))
             .then(one_of("+-").or_not())
-            .then(digits.clone());
+            .then(digits);
 
         let number = just('-')
             .or_not()

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -9,6 +9,7 @@ enum Token {
     Parens(Vec<Token>),
 }
 
+#[allow(clippy::let_and_return)]
 fn parser<'a>() -> impl Parser<'a, &'a [Token], i64> {
     recursive(|expr| {
         let num = select_ref! { Token::Num(x) => *x };

--- a/examples/nested_spans.rs
+++ b/examples/nested_spans.rs
@@ -11,6 +11,7 @@ enum Token {
 
 type TokenTreeInput<'a> = SpannedInput<Token, SimpleSpan, &'a [(Token, SimpleSpan)]>;
 
+#[allow(clippy::let_and_return)]
 fn parser<'a>() -> impl Parser<'a, TokenTreeInput<'a>, i64> {
     recursive(|expr| {
         let num = select_ref! { Token::Num(x) => *x };

--- a/src/container.rs
+++ b/src/container.rs
@@ -812,6 +812,7 @@ mod test {
         for idx in 0..C::LEN {
             C::write(&mut uninit, idx, idx);
         }
+        // SAFETY: All elements were initialized.
         unsafe { C::take(uninit) }
     }
 
@@ -820,6 +821,7 @@ mod test {
         for idx in 0..(C::LEN / 2) {
             C::write(&mut uninit, idx, idx);
         }
+        // SAFETY: All elements up to this point were initialized.
         unsafe { C::drop_before(&mut uninit, C::LEN / 2) };
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,13 +6,15 @@
 //! ways: from strings, slices, arrays, etc.
 
 pub use crate::stream::{BoxedExactSizeStream, BoxedStream, Stream};
-use core::cell::RefCell;
 
 use super::*;
 #[cfg(feature = "memoization")]
 use hashbrown::HashMap;
 #[cfg(feature = "std")]
-use std::io::{BufReader, Read, Seek};
+use std::{
+    cell::RefCell,
+    io::{BufReader, Read, Seek},
+};
 
 /// A trait for types that represents a stream of input tokens. Unlike [`Iterator`], this type
 /// supports backtracking and a few other features required by the crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3027,7 +3027,7 @@ mod tests {
         }
 
         let mut chars = String::new();
-        for c in parser().parse_iter(&"abcdefg").into_result().unwrap() {
+        for c in parser().parse_iter("abcdefg").into_result().unwrap() {
             chars.push(c);
         }
 
@@ -3409,7 +3409,7 @@ mod tests {
             many_as.into_iter().collect()
         }
 
-        assert_eq!(parser().parse("aaa").into_result().unwrap(), ());
+        assert_eq!(parser().parse("aaa").into_result(), Ok(()));
     }
 
     #[test]
@@ -3437,10 +3437,7 @@ mod tests {
                 let s = "hello".to_string();
 
                 assert_eq!(parser.get().parse(&s).into_result(), Ok("hello"));
-                assert!(matches!(
-                    parser.get().parse("goodbye").into_result(),
-                    Err(_)
-                ));
+                assert!(parser.get().parse("goodbye").into_result().is_err());
             }
         }
 
@@ -3452,10 +3449,7 @@ mod tests {
                 let parser = crate::cache::Cache::new(MyCache);
 
                 assert_eq!(parser.get().parse(&s).into_result(), Ok("hello"));
-                assert!(matches!(
-                    parser.get().parse("goodbye").into_result(),
-                    Err(_)
-                ));
+                assert!(parser.get().parse("goodbye").into_result().is_err());
             }
         }
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -130,9 +130,9 @@ mod tests {
         #[test]
         fn subnorm() {
             for bits in 0u32..(1 << 21) {
-                let single: f32 = unsafe { core::mem::transmute(bits) };
+                let single: f32 = f32::from_bits(bits);
                 validate(&format!("{:e}", single));
-                let double: f64 = unsafe { core::mem::transmute(bits as u64) };
+                let double: f64 = f64::from_bits(bits as u64);
                 validate(&format!("{:e}", double));
             }
         }


### PR DESCRIPTION
This should prevent them from becoming out-of-date. I chose not to test them with the MSRV since it would be an unnecessary restriction. Closes #579.

Note: Is the use/position of `#[allow(clippy::let_and_return)]` okay, should it be moved, or should it be removed and fixed?