### PR TITLE
Use diagnostic namespace, make message appear on ParserSealed mismatches

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3501,8 +3501,3 @@ mod tests {
         }
     }
 }
-
-fn foo() {
-    use prelude::*;
-    let p = any::<&str, extra::Default>().or(any().to(()));
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 #![cfg_attr(
     feature = "nightly",
-    feature(never_type, rustc_attrs, fn_traits, tuple_trait, unboxed_closures)
+    feature(never_type, fn_traits, tuple_trait, unboxed_closures, diagnostic_namespace)
 )]
 //
 // README.md links these files via the main branch. For docs.rs we however want to link them
@@ -351,9 +351,9 @@ impl<T, E> ParseResult<T, E> {
 ///    implement it in chumsky itself.
 #[cfg_attr(
     feature = "nightly",
-    rustc_on_unimplemented(
-        message = "`{Self}` is not a parser from `{I}` to `{O}`",
-        label = "This parser is not compatible because it does not implement `Parser<{I}, {O}>`",
+    diagnostic::on_unimplemented(
+        message = "The following is not a parser from `{I}` to `{O}`: `{Self}`",
+        label = "This parser is not compatible because it does not implement `Parser<{I}, {O}, E>`",
         note = "You should check that the output types of your parsers are consistent with the combinators you're using",
     )
 )]
@@ -3500,4 +3500,9 @@ mod tests {
             todo().map_with(|expr, e| (expr, e.span()))
         }
     }
+}
+
+fn foo() {
+    use prelude::*;
+    let p = any::<&str, extra::Default>().or(any().to(()));
 }

--- a/src/private.rs
+++ b/src/private.rs
@@ -212,6 +212,14 @@ impl Mode for Check {
 // TODO: Consider removing these sealed traits in favour of `Sealed`, with the given methods just being on `Parser`
 // with doc(hidden)
 
+#[cfg_attr(
+    feature = "nightly",
+    diagnostic::on_unimplemented(
+        message = "The following is not a parser from `{I}` to `{O}`: `{Self}`",
+        label = "This parser is not compatible because it does not implement `Parser<{I}, {O}, E>`",
+        note = "You should check that the output types of your parsers are consistent with the combinators you're using",
+    )
+)]
 pub trait ParserSealed<'a, I: Input<'a>, O, E: ParserExtra<'a, I>> {
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O>
     where

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -122,7 +122,7 @@ where
         }
 
         // Get the token at the given offset
-        let tok = vec.get(offset).map(I::Item::clone);
+        let tok = vec.get(offset).cloned();
 
         self.tokens.swap(&other);
 


### PR DESCRIPTION
This should slightly improve the situation for trait errors. We don't get *too* much control over the diagnostic, but I tried to push the bits important to the front.