### PR TITLE
Added Non-Associative associativity for Pratt Parsers.

### DIFF
--- a/src/pratt.rs
+++ b/src/pratt.rs
@@ -10,6 +10,8 @@
 //! ['binding power'](https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html#From-Precedence-to-Binding-Power)
 //! that determines how strongly operators should bind to the operands around them.
 //!
+//! Here is ['another approach'](https://www.engr.mun.ca/~theo/Misc/pratt_parsing.htm) that provides a more comprehensive perspective of handling multiple operators and patterns
+//!
 //! Pratt parsers are defined with the [`Parser::pratt`] method.
 //!
 //! When writing pratt parsers, it is necessary to first define an 'atomic' operand used by the parser for building up
@@ -757,10 +759,9 @@ mod tests {
             ))
             .map(|x| x.to_string());
 
-        assert_eq!(
-            parser.parse("1+2!$*3").into_result(),
-            Ok("(((1 + (2!))$) * 3)".to_string()),
-        )
+        assert!(
+            parser.parse("§1+-~2!$*3").has_errors(),
+        );
     }
 
     #[test]

--- a/src/pratt.rs
+++ b/src/pratt.rs
@@ -176,7 +176,7 @@ impl Associativity {
     fn next_power(&self) -> u32 {
         match self {
             Self::Left(x) => *x as u32 * 3,
-            Self::Left(x) => *x as u32 * 3,
+            Self::Right(x) => *x as u32 * 3,
             Self::Non(x) => *x as u32 * 3 - 1,
         }
     }


### PR DESCRIPTION
In current Pratt parsers, only associativity type of `left` and `right` are supported. However, according to the original designs of Pratt parsing, it should also support Non-Associative infix binary operators.

For example, consider operators `==` as a non-associative operator. We should be able to identify it as non-associative and therefore rejecting `1 == 2 == 3` as an expression with the numbers being atomic literals. Whilst the current design only allow `==` to be either left-associative or right-associative.

This PR added associativity `non` for infix binary operators, and changed the binding power calculation function slightly based on [The Original Parsing Methodology](https://dl.acm.org/doi/pdf/10.1145/512927.512931) and [this article](https://www.engr.mun.ca/~theo/Misc/pratt_parsing.htm).