### PR TITLE
docs: hyperlink `then*` methods with each other

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -892,6 +892,9 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     ///
     /// The output type of this parser is `(O, U)`, a combination of the outputs of both parsers.
     ///
+    /// If you instead only need the output of __one__ of the parsers, use [`ignore_then`](Self::ignore_then)
+    /// or [`then_ignore`](Self::then_ignore).
+    ///
     /// # Examples
     ///
     /// ```
@@ -920,6 +923,9 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     /// Parse one thing and then another thing, yielding only the output of the latter.
     ///
     /// The output type of this parser is `U`, the same as the second parser.
+    ///
+    /// If you instead only need the output of the first parser, use [`then_ignore`](Self::then_ignore).
+    /// If you need the output of __both__ parsers, use [`then`](Self::then).
     ///
     /// # Examples
     ///
@@ -951,6 +957,9 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     /// Parse one thing and then another thing, yielding only the output of the former.
     ///
     /// The output type of this parser is `O`, the same as the original parser.
+    ///
+    /// If you instead only need the output of the second parser, use [`ignore_then`](Self::ignore_then).
+    /// If you need the output of __both__ parsers, use [`then`](Self::then).
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This hyperlinks `then`, `then_ignore` and `ignore_then` methods to each other and provides a short note when the other method(s) should be used. This improves discoverability of the methods and makes the similarity between those methods more obvious.

This is especially useful, when one navigates to those methods by using the _alphabetically sorted_ docs.rs menu on the side, because e.g. the methods `then_ignore` and `ignore_then` are pretty far apart in this side-menu despite their similar purpose.