### PR TITLE
Use diagnostic namespace on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ std = [
     "serde?/std"
 ]
 
-# Enable nightly-only features like better compiler diagnostics and a Parser impl for ! (the never type).
+# Enable nightly-only features like some experimental combinators and a Parser impl for ! (the never type).
 nightly = []
 
 # Allows deeper recursion by dynamically spilling stack state on to the heap.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,13 +349,10 @@ impl<T, E> ParseResult<T, E> {
 ///
 /// 4) If you believe you've found a common use-case that's missing from chumsky, you could open a pull request to
 ///    implement it in chumsky itself.
-#[cfg_attr(
-    feature = "nightly",
-    diagnostic::on_unimplemented(
-        message = "The following is not a parser from `{I}` to `{O}`: `{Self}`",
-        label = "This parser is not compatible because it does not implement `Parser<{I}, {O}, E>`",
-        note = "You should check that the output types of your parsers are consistent with the combinators you're using",
-    )
+#[diagnostic::on_unimplemented(
+    message = "The following is not a parser from `{I}` to `{O}`: `{Self}`",
+    label = "This parser is not compatible because it does not implement `Parser<{I}, {O}, E>`",
+    note = "You should check that the output types of your parsers are consistent with the combinators you're using"
 )]
 pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     ParserSealed<'a, I, O, E>

--- a/src/private.rs
+++ b/src/private.rs
@@ -212,13 +212,10 @@ impl Mode for Check {
 // TODO: Consider removing these sealed traits in favour of `Sealed`, with the given methods just being on `Parser`
 // with doc(hidden)
 
-#[cfg_attr(
-    feature = "nightly",
-    diagnostic::on_unimplemented(
-        message = "The following is not a parser from `{I}` to `{O}`: `{Self}`",
-        label = "This parser is not compatible because it does not implement `Parser<{I}, {O}, E>`",
-        note = "You should check that the output types of your parsers are consistent with the combinators you're using",
-    )
+#[diagnostic::on_unimplemented(
+    message = "The following is not a parser from `{I}` to `{O}`: `{Self}`",
+    label = "This parser is not compatible because it does not implement `Parser<{I}, {O}, E>`",
+    note = "You should check that the output types of your parsers are consistent with the combinators you're using"
 )]
 pub trait ParserSealed<'a, I: Input<'a>, O, E: ParserExtra<'a, I>> {
     fn go<M: Mode>(&self, inp: &mut InputRef<'a, '_, I, E>) -> PResult<M, O>


### PR DESCRIPTION
`#[diagnostic::on_unimplemented]` was stabilized in Rust 1.78.0 :)