### PR TITLE
Update `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chumsky"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "ariadne",
  "ciborium",


### PR DESCRIPTION
As of commit ef9f20f6177b938550d0c12889c5d2dbac85558f, cloning and building the repo results in an extraneous diff on `Cargo.lock`, which this PR fixes.