### PR TITLE
fix: #631 revert change in label.rs to fix error labels

### DIFF
--- a/src/label.rs
+++ b/src/label.rs
@@ -57,7 +57,7 @@ where
         inp.errors.alt = old_alt;
 
         if let Some(mut new_alt) = new_alt {
-            let before_next = before.offset.into();
+            let before_next = before.offset.into() + 1;
             if new_alt.pos.into() == before_next {
                 new_alt.err.label_with(self.label.clone());
             } else if self.is_context && new_alt.pos.into() > before_next {


### PR DESCRIPTION
When a source does not contain a newline,  labels are lost/ignored and replaced with the fallback `expected something else`.

This reverts the change made in this commit which appears to fix this https://github.com/zesterer/chumsky/commit/68375371a5fde6ee14f190c14e9a9cee0697f022#diff-3d2dfe7e70ee2398dd0941e8f6ea855652695c3f82b7816f649668fb2d56b93dR60