### PR TITLE
Fix string lexer in `nano-rust` example

### DIFF
--- a/examples/nano_rust.rs
+++ b/examples/nano_rust.rs
@@ -56,9 +56,8 @@ fn lexer<'src>(
 
     // A parser for strings
     let str_ = just('"')
-        .ignore_then(none_of('"').repeated())
+        .ignore_then(none_of('"').repeated().to_slice())
         .then_ignore(just('"'))
-        .to_slice()
         .map(Token::Str);
 
     // A parser for operators


### PR DESCRIPTION
Hey!
I noticed a small bug in the `nano_rust` example where the string lexer doesn't properly ignore the delimiting `"` characters. Here's a fix!