### PR TITLE
Improved pratt ergonomics, added Mini ML example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,4 +144,4 @@ required-features = ["std"]
 
 [[example]]
 name = "mini_ml"
-required-features = ["pratt"]
+required-features = ["pratt", "label"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,3 +141,7 @@ required-features = ["std"]
 [[example]]
 name = "foo"
 required-features = ["std"]
+
+[[example]]
+name = "mini_ml"
+required-features = ["pratt"]

--- a/examples/mini_ml.rs
+++ b/examples/mini_ml.rs
@@ -1,0 +1,139 @@
+use chumsky::{
+    input::{MapExtra, SpannedInput},
+    pratt::*,
+    prelude::*,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Token<'src> {
+    Ident(&'src str),
+    Num(f64),
+    Parens(Vec<Spanned<Self>>),
+
+    // Ops
+    Eq,
+    Plus,
+    Asterisk,
+
+    // Keywords
+    Let,
+    In,
+}
+
+pub type Spanned<T> = (T, SimpleSpan);
+
+fn lexer<'src>(
+) -> impl Parser<'src, &'src str, Vec<Spanned<Token<'src>>>, extra::Err<Rich<'src, char>>> {
+    recursive(|token| {
+        let keyword = text::ident().map(|s| match s {
+            "let" => Token::Let,
+            "in" => Token::In,
+            s => Token::Ident(s),
+        });
+
+        let num = text::int(10)
+            .then(just('.').then(text::digits(10)).or_not())
+            .to_slice()
+            .map(|s: &str| Token::Num(s.parse().unwrap()));
+
+        let op = choice((
+            just("=").to(Token::Eq),
+            just("+").to(Token::Plus),
+            just("*").to(Token::Asterisk),
+        ));
+
+        choice((
+            keyword,
+            op,
+            num,
+            token
+                .repeated()
+                .collect()
+                .delimited_by(just('(').padded(), just(')').padded())
+                .map(Token::Parens),
+        ))
+        .map_with(|t, e| (t, e.span()))
+        .padded()
+    })
+    .repeated()
+    .collect()
+}
+
+#[derive(Debug)]
+pub enum Expr<'src> {
+    Local(&'src str),
+    Num(f64),
+    Let(&'src str, Box<Spanned<Self>>, Box<Spanned<Self>>),
+    Add(Box<Spanned<Self>>, Box<Spanned<Self>>),
+    Mul(Box<Spanned<Self>>, Box<Spanned<Self>>),
+    Call(Box<Spanned<Self>>, Box<Spanned<Self>>),
+}
+
+type ParserInput<'src> = SpannedInput<Token<'src>, SimpleSpan, &'src [Spanned<Token<'src>>]>;
+
+fn parser<'src>(
+) -> impl Parser<'src, ParserInput<'src>, Spanned<Expr<'src>>, extra::Err<Rich<'src, Token<'src>>>>
+{
+    recursive(|expr| {
+        let ident = select_ref! { Token::Ident(x) => *x };
+        let atom = choice((
+            select_ref! { Token::Num(x) => Expr::Num(*x) },
+            ident.map(Expr::Local),
+            // let x = y in z
+            just(Token::Let)
+                .ignore_then(ident)
+                .then_ignore(just(Token::Eq))
+                .then(expr.clone())
+                .then_ignore(just(Token::In))
+                .then(expr.clone())
+                .map(|((lhs, rhs), then)| Expr::Let(lhs, Box::new(rhs), Box::new(then))),
+        ));
+
+        atom.map_with(|expr, e| (expr, e.span()))
+            // ( x )
+            .or(expr.nested_in(
+                select_ref! { Token::Parens(ts) = e => ts.as_slice().spanned(e.span()) },
+            ))
+            .pratt((
+                // Multiply
+                infix(
+                    left(10),
+                    just(Token::Asterisk),
+                    |x, _, y, e: &mut MapExtra<'src, '_, _, _>| {
+                        (Expr::Mul(Box::new(x), Box::new(y)), e.span())
+                    },
+                ),
+                // Add
+                infix(
+                    left(9),
+                    just(Token::Plus),
+                    |x, _, y, e: &mut MapExtra<'src, '_, _, _>| {
+                        (Expr::Add(Box::new(x), Box::new(y)), e.span())
+                    },
+                ),
+                // Calls
+                infix(
+                    left(1),
+                    empty(),
+                    |x, _, y, e: &mut MapExtra<'src, '_, _, _>| {
+                        (Expr::Call(Box::new(x), Box::new(y)), e.span())
+                    },
+                ),
+            ))
+    })
+}
+
+fn main() {
+    let text = "
+        let x = (5 + 42) * 2 in
+        add x 3.5
+    ";
+
+    let tokens = lexer().parse(text).unwrap();
+
+    dbg!(&tokens);
+
+    let expr = parser().parse(tokens.spanned((0..text.len()).into()));
+
+    dbg!(expr);
+}

--- a/examples/mini_ml.rs
+++ b/examples/mini_ml.rs
@@ -1,6 +1,11 @@
+//! This is an entire lexer, parser, type-checker, and interpreter for a statically-typed ML-like functional
+//! programming language. See `sample.mini_ml` for sample source code.
+//! Run it with the following command:
+//! cargo run --features=pratt,label --example mini_ml -- examples/sample.mini_ml
+
 use ariadne::{sources, Color, Label, Report, ReportKind};
 use chumsky::{input::SpannedInput, pratt::*, prelude::*};
-use core::fmt;
+use std::{env, fmt, fs};
 
 // Tokens and lexer
 
@@ -438,12 +443,8 @@ fn parse_failure(err: &Rich<impl fmt::Display>, src: &str) -> ! {
 }
 
 fn main() {
-    let src = "
-        let add = fn x y = x + y in
-        let mul = fn x y = x * y in
-        let x = mul (add 5 42) 2 in
-        add x 3.5
-    ";
+    let filename = env::args().nth(1).expect("Expected file argument");
+    let src = &fs::read_to_string(&filename).expect("Failed to read file");
 
     let tokens = lexer()
         .parse(src)

--- a/examples/mini_ml.rs
+++ b/examples/mini_ml.rs
@@ -1,8 +1,4 @@
-use chumsky::{
-    input::{MapExtra, SpannedInput},
-    pratt::*,
-    prelude::*,
-};
+use chumsky::{input::SpannedInput, pratt::*, prelude::*};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token<'src> {

--- a/examples/mini_ml.rs
+++ b/examples/mini_ml.rs
@@ -152,15 +152,17 @@ fn parser<'src>(
                 select_ref! { Token::Parens(ts) = e => ts.as_slice().spanned(e.span()) },
             ),
         ))
-        .pratt((
+        .pratt(vec![
             // Multiply
             infix(left(10), just(Token::Asterisk), |x, _, y, e| {
                 (Expr::Mul(Box::new(x), Box::new(y)), e.span())
-            }),
+            })
+            .boxed(),
             // Add
             infix(left(9), just(Token::Plus), |x, _, y, e| {
                 (Expr::Add(Box::new(x), Box::new(y)), e.span())
-            }),
+            })
+            .boxed(),
             // Calls
             infix(left(1), empty(), |x, _, y, e| {
                 (
@@ -170,8 +172,9 @@ fn parser<'src>(
                     },
                     e.span(),
                 )
-            }),
-        ))
+            })
+            .boxed(),
+        ])
         .labelled("expression")
         .as_context()
     })

--- a/examples/mini_ml.rs
+++ b/examples/mini_ml.rs
@@ -105,29 +105,17 @@ fn parser<'src>(
             ))
             .pratt((
                 // Multiply
-                infix(
-                    left(10),
-                    just(Token::Asterisk),
-                    |x, _, y, e: &mut MapExtra<'src, '_, _, _>| {
-                        (Expr::Mul(Box::new(x), Box::new(y)), e.span())
-                    },
-                ),
+                infix(left(10), just(Token::Asterisk), |x, _, y, e| {
+                    (Expr::Mul(Box::new(x), Box::new(y)), e.span())
+                }),
                 // Add
-                infix(
-                    left(9),
-                    just(Token::Plus),
-                    |x, _, y, e: &mut MapExtra<'src, '_, _, _>| {
-                        (Expr::Add(Box::new(x), Box::new(y)), e.span())
-                    },
-                ),
+                infix(left(9), just(Token::Plus), |x, _, y, e| {
+                    (Expr::Add(Box::new(x), Box::new(y)), e.span())
+                }),
                 // Calls
-                infix(
-                    left(1),
-                    empty(),
-                    |x, _, y, e: &mut MapExtra<'src, '_, _, _>| {
-                        (Expr::Call(Box::new(x), Box::new(y)), e.span())
-                    },
-                ),
+                infix(left(1), empty(), |x, _, y, e| {
+                    (Expr::Call(Box::new(x), Box::new(y)), e.span())
+                }),
             ))
     })
 }

--- a/examples/mini_ml.rs
+++ b/examples/mini_ml.rs
@@ -15,6 +15,8 @@ pub enum Token<'src> {
     Let,
     In,
     Fn,
+    True,
+    False,
 }
 
 pub type Spanned<T> = (T, SimpleSpan);
@@ -26,6 +28,8 @@ fn lexer<'src>(
             "let" => Token::Let,
             "in" => Token::In,
             "fn" => Token::Fn,
+            "true" => Token::True,
+            "false" => Token::False,
             s => Token::Ident(s),
         });
 
@@ -57,15 +61,26 @@ fn lexer<'src>(
     .collect()
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Expr<'src> {
-    Local(&'src str),
+    Var(&'src str),
     Num(f64),
-    Let(Spanned<&'src str>, Box<Spanned<Self>>, Box<Spanned<Self>>),
+    Bool(bool),
     Add(Box<Spanned<Self>>, Box<Spanned<Self>>),
     Mul(Box<Spanned<Self>>, Box<Spanned<Self>>),
-    Call(Box<Spanned<Self>>, Box<Spanned<Self>>),
-    Func(Vec<Spanned<&'src str>>, Box<Spanned<Self>>),
+    Let {
+        lhs: Spanned<&'src str>,
+        rhs: Box<Spanned<Self>>,
+        then: Box<Spanned<Self>>,
+    },
+    Apply {
+        func: Box<Spanned<Self>>,
+        arg: Box<Spanned<Self>>,
+    },
+    Func {
+        arg: Box<Spanned<&'src str>>,
+        body: Box<Spanned<Self>>,
+    },
 }
 
 type ParserInput<'src> = SpannedInput<Token<'src>, SimpleSpan, &'src [Spanned<Token<'src>>]>;
@@ -77,7 +92,9 @@ fn parser<'src>(
         let ident = select_ref! { Token::Ident(x) => *x };
         let atom = choice((
             select_ref! { Token::Num(x) => Expr::Num(*x) },
-            ident.map(Expr::Local),
+            just(Token::True).to(Expr::Bool(true)),
+            just(Token::False).to(Expr::Bool(false)),
+            ident.map(Expr::Var),
             // let x = y in z
             just(Token::Let)
                 .ignore_then(ident.map_with(|x, e| (x, e.span())))
@@ -85,35 +102,161 @@ fn parser<'src>(
                 .then(expr.clone())
                 .then_ignore(just(Token::In))
                 .then(expr.clone())
-                .map(|((lhs, rhs), then)| Expr::Let(lhs, Box::new(rhs), Box::new(then))),
-            // fn x y = z
-            just(Token::Fn)
-                .ignore_then(ident.map_with(|x, e| (x, e.span())).repeated().collect())
-                .then_ignore(just(Token::Eq))
-                .then(expr.clone())
-                .map(|(args, body)| Expr::Func(args, Box::new(body))),
+                .map(|((lhs, rhs), then)| Expr::Let {
+                    lhs,
+                    rhs: Box::new(rhs),
+                    then: Box::new(then),
+                }),
         ));
 
-        atom.map_with(|expr, e| (expr, e.span()))
+        choice((
+            atom.map_with(|expr, e| (expr, e.span())),
+            // fn x y = z
+            just(Token::Fn).ignore_then(
+                ident.map_with(|x, e| (x, e.span())).repeated().foldr_with(
+                    just(Token::Eq).ignore_then(expr.clone()),
+                    |arg, body, e| {
+                        (
+                            Expr::Func {
+                                arg: Box::new(arg),
+                                body: Box::new(body),
+                            },
+                            e.span(),
+                        )
+                    },
+                ),
+            ),
             // ( x )
-            .or(expr.nested_in(
+            expr.nested_in(
                 select_ref! { Token::Parens(ts) = e => ts.as_slice().spanned(e.span()) },
-            ))
-            .pratt((
-                // Multiply
-                infix(left(10), just(Token::Asterisk), |x, _, y, e| {
-                    (Expr::Mul(Box::new(x), Box::new(y)), e.span())
-                }),
-                // Add
-                infix(left(9), just(Token::Plus), |x, _, y, e| {
-                    (Expr::Add(Box::new(x), Box::new(y)), e.span())
-                }),
-                // Calls
-                infix(left(1), empty(), |x, _, y, e| {
-                    (Expr::Call(Box::new(x), Box::new(y)), e.span())
-                }),
-            ))
+            ),
+        ))
+        .pratt((
+            // Multiply
+            infix(left(10), just(Token::Asterisk), |x, _, y, e| {
+                (Expr::Mul(Box::new(x), Box::new(y)), e.span())
+            }),
+            // Add
+            infix(left(9), just(Token::Plus), |x, _, y, e| {
+                (Expr::Add(Box::new(x), Box::new(y)), e.span())
+            }),
+            // Calls
+            infix(left(1), empty(), |x, _, y, e| {
+                (
+                    Expr::Apply {
+                        func: Box::new(x),
+                        arg: Box::new(y),
+                    },
+                    e.span(),
+                )
+            }),
+        ))
     })
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+struct TyVar(usize);
+
+#[derive(Copy, Clone, Debug)]
+enum TyInfo {
+    Unknown,
+    Ref(TyVar),
+    Num,
+    Bool,
+    Func(TyVar, TyVar),
+}
+
+#[derive(Debug)]
+enum Ty {
+    Num,
+    Bool,
+    Func(Box<Self>, Box<Self>),
+}
+
+#[derive(Default)]
+struct Solver {
+    vars: Vec<TyInfo>,
+}
+
+impl Solver {
+    fn create_ty(&mut self, info: TyInfo) -> TyVar {
+        self.vars.push(info);
+        TyVar(self.vars.len() - 1)
+    }
+
+    fn unify(&mut self, a: TyVar, b: TyVar) {
+        match (self.vars[a.0], self.vars[b.0]) {
+            (TyInfo::Unknown, _) => self.vars[a.0] = TyInfo::Ref(b),
+            (_, TyInfo::Unknown) => self.vars[b.0] = TyInfo::Ref(a),
+            (TyInfo::Ref(a), _) => self.unify(a, b),
+            (_, TyInfo::Ref(b)) => self.unify(a, b),
+            (TyInfo::Num, TyInfo::Num) | (TyInfo::Bool, TyInfo::Bool) => {}
+            (TyInfo::Func(a_i, a_o), TyInfo::Func(b_i, b_o)) => {
+                self.unify(a_i, b_i);
+                self.unify(a_o, b_o);
+            }
+            (a, b) => panic!("Type mismatch between {a:?} and {b:?}"),
+        }
+    }
+
+    fn check<'ast>(&mut self, expr: &Expr<'ast>, env: &mut Vec<(&'ast str, TyVar)>) -> TyVar {
+        match expr {
+            // Literal expressions are easy, their type doesn't need inferring.
+            Expr::Num(_) => self.create_ty(TyInfo::Num),
+            Expr::Bool(_) => self.create_ty(TyInfo::Bool),
+            // We search the environment backward until we find a binding matching the variable name.
+            Expr::Var(name) => {
+                env.iter_mut()
+                    .rev()
+                    .find(|(n, _)| n == name)
+                    .expect("No such variable in scope")
+                    .1
+            }
+            // In a let expression, `rhs` gets bound with name `lhs` in the environment used to type-check `then`.
+            Expr::Let { lhs, rhs, then } => {
+                let rhs = self.check(&rhs.0, env);
+                env.push((lhs.0, rhs));
+                let out = self.check(&then.0, env);
+                env.pop();
+                out
+            }
+            // In a function, the argument becomes an unknown type in the environment used to type-check `body`.
+            Expr::Func { arg, body } => {
+                let arg_ty = self.create_ty(TyInfo::Unknown);
+                env.push((arg.0, arg_ty));
+                let body = self.check(&body.0, env);
+                env.pop();
+                self.create_ty(TyInfo::Func(arg_ty, body))
+            }
+            // During function application, both argument and function are type-checked and then we force the latter to be a function of the former.
+            Expr::Apply { func, arg } => {
+                let func = self.check(&func.0, env);
+                let arg = self.check(&arg.0, env);
+                let out = self.create_ty(TyInfo::Unknown);
+                let func_ty = self.create_ty(TyInfo::Func(arg, out));
+                self.unify(func_ty, func);
+                out
+            }
+            Expr::Add(l, r) | Expr::Mul(l, r) => {
+                let out = self.create_ty(TyInfo::Num);
+                let l = self.check(&l.0, env);
+                self.unify(out, l);
+                let r = self.check(&r.0, env);
+                self.unify(out, r);
+                out
+            }
+        }
+    }
+
+    pub fn solve(&self, var: TyVar) -> Ty {
+        match self.vars[var.0] {
+            TyInfo::Unknown => panic!("Cannot infer type"),
+            TyInfo::Ref(var) => self.solve(var),
+            TyInfo::Num => Ty::Num,
+            TyInfo::Bool => Ty::Bool,
+            TyInfo::Func(i, o) => Ty::Func(Box::new(self.solve(i)), Box::new(self.solve(o))),
+        }
+    }
 }
 
 fn main() {
@@ -128,7 +271,18 @@ fn main() {
 
     dbg!(&tokens);
 
-    let expr = parser().parse(tokens.spanned((0..text.len()).into()));
+    let expr = parser()
+        .parse(tokens.spanned((0..text.len()).into()))
+        .unwrap();
 
-    dbg!(expr);
+    dbg!(&expr);
+
+    let mut solver = Solver::default();
+
+    let program_ty = solver.check(&expr.0, &mut Vec::new());
+
+    println!(
+        "The expression outputs type `{:?}`",
+        solver.solve(program_ty)
+    );
 }

--- a/examples/mini_ml.rs
+++ b/examples/mini_ml.rs
@@ -33,7 +33,7 @@ impl fmt::Display for Token<'_> {
             Token::Plus => write!(f, "+"),
             Token::Asterisk => write!(f, "*"),
             Token::Let => write!(f, "let"),
-            Token::In => write!(f, "'in"),
+            Token::In => write!(f, "in"),
             Token::Fn => write!(f, "fn"),
             Token::True => write!(f, "true"),
             Token::False => write!(f, "false"),
@@ -244,7 +244,7 @@ impl Solver<'_> {
             }
             (a_info, b_info) => failure(
                 format!("Type mismatch between {a_info} and {b_info}"),
-                (format!("mismatch occurred here"), span),
+                ("mismatch occurred here".to_string(), span),
                 vec![
                     (format!("{a_info}"), self.vars[a.0].1),
                     (format!("{b_info}"), self.vars[b.0].1),
@@ -312,7 +312,7 @@ impl Solver<'_> {
     pub fn solve(&self, var: TyVar) -> Ty {
         match self.vars[var.0].0 {
             TyInfo::Unknown => failure(
-                format!("Cannot infer type"),
+                "Cannot infer type".to_string(),
                 ("has unknown type".to_string(), self.vars[var.0].1),
                 None,
                 self.src,

--- a/examples/sample.mini_ml
+++ b/examples/sample.mini_ml
@@ -1,0 +1,4 @@
+let add = fn x y = x + y in
+let mul = fn x y = x * y in
+let x = mul (add 5 42) 2 in
+add x 3.5

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2130,7 +2130,6 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     /// ```
     /// # use chumsky::prelude::*;
     /// use chumsky::pratt::*;
-    /// use std::ops::{Neg, Mul, Div, Add, Sub};
     ///
     /// let int = text::int::<_, _, extra::Err<Rich<char>>>(10)
     ///     .from_str()
@@ -2140,11 +2139,11 @@ pub trait Parser<'a, I: Input<'a>, O, E: ParserExtra<'a, I> = extra::Default>:
     /// let op = |c| just(c).padded();
     ///
     /// let expr = int.pratt((
-    ///     prefix(2, op('-'), i64::neg),
-    ///     infix(left(1), op('*'), i64::mul),
-    ///     infix(left(1), op('/'), i64::div),
-    ///     infix(left(0), op('+'), i64::add),
-    ///     infix(left(0), op('-'), i64::sub),
+    ///     prefix(2, op('-'), |_, x: i64, _| -x),
+    ///     infix(left(1), op('*'), |x, _, y, _| x * y),
+    ///     infix(left(1), op('/'), |x, _, y, _| x / y),
+    ///     infix(left(0), op('+'), |x, _, y, _| x + y),
+    ///     infix(left(0), op('-'), |x, _, y, _| x - y),
     /// ));
     ///
     /// // Pratt parsing can handle unary operators...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ use self::{
     input::{
         BorrowInput, Emitter, ExactSizeInput, InputRef, MapExtra, SliceInput, StrInput, ValueInput,
     },
+    inspector::Inspector,
     prelude::*,
     primitive::Any,
     private::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,9 @@ mod sync {
     pub(crate) type RefC<T> = alloc::sync::Arc<T>;
     pub(crate) type RefW<T> = alloc::sync::Weak<T>;
     pub(crate) type DynParser<'a, 'b, I, O, E> = dyn Parser<'a, I, O, E> + Send + Sync + 'b;
+    #[cfg(feature = "pratt")]
+    pub(crate) type DynOperator<'a, 'b, I, O, E> =
+        dyn pratt::Operator<'a, I, O, E> + Send + Sync + 'b;
 
     /// A trait that requires either nothing or `Send` and `Sync` bounds depending on whether the `sync` feature is
     /// enabled. Used to constrain API usage succinctly and easily.
@@ -199,6 +202,8 @@ mod sync {
     pub(crate) type RefC<T> = alloc::rc::Rc<T>;
     pub(crate) type RefW<T> = alloc::rc::Weak<T>;
     pub(crate) type DynParser<'a, 'b, I, O, E> = dyn Parser<'a, I, O, E> + 'b;
+    #[cfg(feature = "pratt")]
+    pub(crate) type DynOperator<'a, 'b, I, O, E> = dyn pratt::Operator<'a, I, O, E> + 'b;
 
     /// A trait that requires either nothing or `Send` and `Sync` bounds depending on whether the `sync` feature is
     /// enabled. Used to constrain API usage succinctly and easily.

--- a/src/pratt.rs
+++ b/src/pratt.rs
@@ -170,8 +170,8 @@ pub struct Infix<'src, A, F, Atom, Op, I, E> {
     phantom: EmptyPhantom<&'src (Atom, Op, I, E)>,
 }
 
-impl<'src, A: Copy, F: Copy, Atom, Op, I, E> Copy for Infix<'src, A, F, Atom, Op, I, E> {}
-impl<'src, A: Clone, F: Clone, Atom, Op, I, E> Clone for Infix<'src, A, F, Atom, Op, I, E> {
+impl<A: Copy, F: Copy, Atom, Op, I, E> Copy for Infix<'_, A, F, Atom, Op, I, E> {}
+impl<A: Clone, F: Clone, Atom, Op, I, E> Clone for Infix<'_, A, F, Atom, Op, I, E> {
     fn clone(&self) -> Self {
         Self {
             op_parser: self.op_parser.clone(),
@@ -245,8 +245,8 @@ pub struct Prefix<'src, A, F, Atom, Op, I, E> {
     phantom: EmptyPhantom<&'src (Atom, Op, I, E)>,
 }
 
-impl<'src, A: Copy, F: Copy, Atom, Op, I, E> Copy for Prefix<'src, A, F, Atom, Op, I, E> {}
-impl<'src, A: Clone, F: Clone, Atom, Op, I, E> Clone for Prefix<'src, A, F, Atom, Op, I, E> {
+impl<A: Copy, F: Copy, Atom, Op, I, E> Copy for Prefix<'_, A, F, Atom, Op, I, E> {}
+impl<A: Clone, F: Clone, Atom, Op, I, E> Clone for Prefix<'_, A, F, Atom, Op, I, E> {
     fn clone(&self) -> Self {
         Self {
             op_parser: self.op_parser.clone(),
@@ -317,8 +317,8 @@ pub struct Postfix<'src, A, F, Atom, Op, I, E> {
     phantom: EmptyPhantom<&'src (Atom, Op, I, E)>,
 }
 
-impl<'src, A: Copy, F: Copy, Atom, Op, I, E> Copy for Postfix<'src, A, F, Atom, Op, I, E> {}
-impl<'src, A: Clone, F: Clone, Atom, Op, I, E> Clone for Postfix<'src, A, F, Atom, Op, I, E> {
+impl<A: Copy, F: Copy, Atom, Op, I, E> Copy for Postfix<'_, A, F, Atom, Op, I, E> {}
+impl<A: Clone, F: Clone, Atom, Op, I, E> Clone for Postfix<'_, A, F, Atom, Op, I, E> {
     fn clone(&self) -> Self {
         Self {
             op_parser: self.op_parser.clone(),

--- a/src/pratt.rs
+++ b/src/pratt.rs
@@ -184,9 +184,9 @@ where
     #[doc(hidden)]
     fn do_parse_prefix<'parse, M: Mode>(
         &self,
-        inp: &mut InputRef<'src, 'parse, I, E>,
-        pre_expr: &input::Cursor<'src, 'parse, I>,
-        f: impl Fn(&mut InputRef<'src, 'parse, I, E>, u32) -> PResult<M, O>,
+        _inp: &mut InputRef<'src, 'parse, I, E>,
+        _pre_expr: &input::Cursor<'src, 'parse, I>,
+        _f: impl Fn(&mut InputRef<'src, 'parse, I, E>, u32) -> PResult<M, O>,
     ) -> PResult<M, O>
     where
         Self: Sized,
@@ -197,9 +197,9 @@ where
     #[doc(hidden)]
     fn do_parse_postfix<'parse, M: Mode>(
         &self,
-        inp: &mut InputRef<'src, 'parse, I, E>,
-        pre_expr: &input::Cursor<'src, 'parse, I>,
-        lhs: M::Output<O>,
+        _inp: &mut InputRef<'src, 'parse, I, E>,
+        _pre_expr: &input::Cursor<'src, 'parse, I>,
+        _lhs: M::Output<O>,
     ) -> Result<M::Output<O>, M::Output<O>>
     where
         Self: Sized,
@@ -210,10 +210,10 @@ where
     #[doc(hidden)]
     fn do_parse_infix<'parse, M: Mode>(
         &self,
-        inp: &mut InputRef<'src, 'parse, I, E>,
-        pre_expr: &input::Cursor<'src, 'parse, I>,
-        lhs: M::Output<O>,
-        f: impl Fn(&mut InputRef<'src, 'parse, I, E>, u32) -> PResult<M, O>,
+        _inp: &mut InputRef<'src, 'parse, I, E>,
+        _pre_expr: &input::Cursor<'src, 'parse, I>,
+        _lhs: M::Output<O>,
+        _f: impl Fn(&mut InputRef<'src, 'parse, I, E>, u32) -> PResult<M, O>,
     ) -> Result<M::Output<O>, M::Output<O>>
     where
         Self: Sized,
@@ -224,9 +224,9 @@ where
     #[doc(hidden)]
     fn do_parse_prefix_check<'parse>(
         &self,
-        inp: &mut InputRef<'src, 'parse, I, E>,
-        pre_expr: &input::Cursor<'src, 'parse, I>,
-        f: &dyn Fn(&mut InputRef<'src, 'parse, I, E>, u32) -> PResult<Check, O>,
+        _inp: &mut InputRef<'src, 'parse, I, E>,
+        _pre_expr: &input::Cursor<'src, 'parse, I>,
+        _f: &dyn Fn(&mut InputRef<'src, 'parse, I, E>, u32) -> PResult<Check, O>,
     ) -> PResult<Check, O>;
     #[doc(hidden)]
     fn do_parse_prefix_emit<'parse>(
@@ -270,13 +270,13 @@ where
 /// A boxed pratt parser operator. See [`Operator`].
 pub struct Boxed<'src, 'a, I, O, E>(RefC<sync::DynOperator<'src, 'a, I, O, E>>);
 
-impl<'src, 'a, I, O, E> Clone for Boxed<'src, 'a, I, O, E> {
+impl<I, O, E> Clone for Boxed<'_, '_, I, O, E> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 }
 
-impl<'src, 'a, I, O, E> Operator<'src, I, O, E> for Boxed<'src, 'a, I, O, E>
+impl<'src, I, O, E> Operator<'src, I, O, E> for Boxed<'src, '_, I, O, E>
 where
     I: Input<'src>,
     E: ParserExtra<'src, I>,


### PR DESCRIPTION
API-wise, this only really includes one breaking change (bar trivial technicalities relating to semi-internal systems): it removes the overloading that pratt operators previously had. The result is that the compiler is much more likely to infer the correct types in user code without annotation.