### PR TITLE
Add input traits implementation for `Graphemes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "spin",
  "stacker",
  "unicode-ident",
+ "unicode-segmentation",
  "vergen-gix",
  "winnow",
 ]
@@ -2192,6 +2193,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ lexical = { version = "6.1.1", default-features = false, features = ["parse-inte
 either = { version = "1.8.1", optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 unicode-ident =  "1.0.10"
+unicode-segmentation = "1"
 
 [build-dependencies]
 vergen-gix = { version = "1.0", optional = true, features = ["emit_and_set"] }

--- a/src/input.rs
+++ b/src/input.rs
@@ -310,7 +310,12 @@ impl<'src> Input<'src> for Graphemes<'src> {
     ) -> Option<Self::MaybeToken> {
         if *cursor < this.len() {
             // SAFETY: `cursor < self.len()` above guarantees cursor is in-bounds
-            //         We only ever return cursors that are at a character boundary
+            //         We only ever return cursors that are at a code point boundary.
+            //         The `next()` implementation returns `None`, only in the 
+            //         situation of zero length of the remaining part of the string. 
+            //         And the Unicode standard guarantees that any sequence of code 
+            //         points is a valid sequence of grapheme clusters, so the 
+            //         behaviour of the `next()` function should not change.
             let c = this
                 .get_unchecked(*cursor..)
                 .graphemes(true)

--- a/src/input.rs
+++ b/src/input.rs
@@ -311,10 +311,10 @@ impl<'src> Input<'src> for Graphemes<'src> {
         if *cursor < this.len() {
             // SAFETY: `cursor < self.len()` above guarantees cursor is in-bounds
             //         We only ever return cursors that are at a code point boundary.
-            //         The `next()` implementation returns `None`, only in the 
-            //         situation of zero length of the remaining part of the string. 
-            //         And the Unicode standard guarantees that any sequence of code 
-            //         points is a valid sequence of grapheme clusters, so the 
+            //         The `next()` implementation returns `None`, only in the
+            //         situation of zero length of the remaining part of the string.
+            //         And the Unicode standard guarantees that any sequence of code
+            //         points is a valid sequence of grapheme clusters, so the
             //         behaviour of the `next()` function should not change.
             let c = this
                 .get_unchecked(*cursor..)


### PR DESCRIPTION
This is to prevent constructs like this `̲0` from being treated as a symbol followed by an number. 

P.S. Extended grapheme clusters are being used.