### PR TITLE
Removed sync feature

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -101,8 +101,6 @@ Chumsky contains several optional features that extend the crate's functionality
 
 - `either`: implements `Parser` for `either::Either`, allowing dynamic configuration of parsers at runtime
 
-- `sync`: enables thread-safe features
-
 - `extension`: enables the extension API, allowing you to write your own first-class combinators that integrate with and extend chumsky
 
 - `memoization`: enables [memoization](https://en.wikipedia.org/wiki/Memoization#Parsers) features

--- a/examples/mini_ml.rs
+++ b/examples/mini_ml.rs
@@ -116,7 +116,7 @@ where
     I: BorrowInput<'src, Token = Token<'src>, Span = SimpleSpan>,
     // Because this function is generic over the input type, we need the caller to tell us how to create a new input,
     // `I`, from a nested token tree. This function serves that purpose.
-    M: Fn(SimpleSpan, &'src [Spanned<Token<'src>>]) -> I + Clone + Send + Sync + 'src,
+    M: Fn(SimpleSpan, &'src [Spanned<Token<'src>>]) -> I + Clone + 'src,
 {
     recursive(|expr| {
         let ident = select_ref! { Token::Ident(x) => *x };

--- a/examples/nested_spans.rs
+++ b/examples/nested_spans.rs
@@ -13,7 +13,7 @@ enum Token {
 fn parser<'src, I, M>(make_input: M) -> impl Parser<'src, I, i64>
 where
     I: BorrowInput<'src, Token = Token, Span = SimpleSpan>,
-    M: Fn(SimpleSpan, &'src [(Token, SimpleSpan)]) -> I + Clone + Send + Sync + 'src,
+    M: Fn(SimpleSpan, &'src [(Token, SimpleSpan)]) -> I + Clone + 'src,
 {
     recursive(|expr| {
         let num = select_ref! { Token::Num(x) => *x };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2638,10 +2638,10 @@ where
 
 /// See [`Parser::boxed`].
 ///
-/// Due to current implementation details, the inner value is not, in fact, a [`Box`], but is an [`Rc`](std::rc::Rc) to facilitate
-/// efficient cloning. This is likely to change in the future. Unlike [`Box`], [`Rc`](std::rc::Rc) has no size guarantees: although
+/// Due to current implementation details, the inner value is not, in fact, a [`Box`], but is an [`Rc`] to facilitate
+/// efficient cloning. This is likely to change in the future. Unlike [`Box`], [`Rc`] has no size guarantees: although
 /// it is *currently* the same size as a raw pointer.
-// TODO: Don't use an Rc
+// TODO: Don't use an Rc (why?)
 pub struct Boxed<'src, 'b, I: Input<'src>, O, E: ParserExtra<'src, I>> {
     inner: Rc<DynParser<'src, 'b, I, O, E>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,13 @@ pub mod prelude {
 }
 
 use crate::input::InputOwn;
-use alloc::{boxed::Box, string::String, vec, vec::Vec};
+use alloc::{
+    boxed::Box,
+    rc::{self, Rc},
+    string::String,
+    vec,
+    vec::Vec,
+};
 #[cfg(feature = "nightly")]
 use core::marker::Tuple;
 use core::{
@@ -176,40 +182,9 @@ impl<T> Unpin for EmptyPhantom<T> {}
 impl<T> core::panic::UnwindSafe for EmptyPhantom<T> {}
 impl<T> core::panic::RefUnwindSafe for EmptyPhantom<T> {}
 
-#[cfg(feature = "sync")]
-mod sync {
-    use super::*;
-
-    pub(crate) type RefC<T> = alloc::sync::Arc<T>;
-    pub(crate) type RefW<T> = alloc::sync::Weak<T>;
-    pub(crate) type DynParser<'src, 'b, I, O, E> = dyn Parser<'src, I, O, E> + Send + Sync + 'b;
-    #[cfg(feature = "pratt")]
-    pub(crate) type DynOperator<'src, 'b, I, O, E> =
-        dyn pratt::Operator<'src, I, O, E> + Send + Sync + 'b;
-
-    /// A trait that requires either nothing or `Send` and `Sync` bounds depending on whether the `sync` feature is
-    /// enabled. Used to constrain API usage succinctly and easily.
-    pub trait MaybeSync: Send + Sync {}
-    impl<T: Send + Sync> MaybeSync for T {}
-}
-
-#[cfg(not(feature = "sync"))]
-mod sync {
-    use super::*;
-
-    pub(crate) type RefC<T> = alloc::rc::Rc<T>;
-    pub(crate) type RefW<T> = alloc::rc::Weak<T>;
-    pub(crate) type DynParser<'src, 'b, I, O, E> = dyn Parser<'src, I, O, E> + 'b;
-    #[cfg(feature = "pratt")]
-    pub(crate) type DynOperator<'src, 'b, I, O, E> = dyn pratt::Operator<'src, I, O, E> + 'b;
-
-    /// A trait that requires either nothing or `Send` and `Sync` bounds depending on whether the `sync` feature is
-    /// enabled. Used to constrain API usage succinctly and easily.
-    pub trait MaybeSync {}
-    impl<T> MaybeSync for T {}
-}
-
-use sync::{DynParser, MaybeSync, RefC, RefW};
+pub(crate) type DynParser<'src, 'b, I, O, E> = dyn Parser<'src, I, O, E> + 'b;
+#[cfg(feature = "pratt")]
+pub(crate) type DynOperator<'src, 'b, I, O, E> = dyn pratt::Operator<'src, I, O, E> + 'b;
 
 /// The result of performing a parse on an input with [`Parser`].
 ///
@@ -2129,10 +2104,10 @@ pub trait Parser<'src, I: Input<'src>, O, E: ParserExtra<'src, I> = extra::Defau
     ///
     fn boxed<'b>(self) -> Boxed<'src, 'b, I, O, E>
     where
-        Self: MaybeSync + Sized + 'src + 'b,
+        Self: Sized + 'src + 'b,
     {
         Boxed {
-            inner: RefC::new(self),
+            inner: Rc::new(self),
         }
     }
 
@@ -2668,7 +2643,7 @@ where
 /// it is *currently* the same size as a raw pointer.
 // TODO: Don't use an Rc
 pub struct Boxed<'src, 'b, I: Input<'src>, O, E: ParserExtra<'src, I>> {
-    inner: RefC<DynParser<'src, 'b, I, O, E>>,
+    inner: Rc<DynParser<'src, 'b, I, O, E>>,
 }
 
 impl<'src, I: Input<'src>, O, E: ParserExtra<'src, I>> Clone for Boxed<'src, '_, I, O, E> {
@@ -2691,7 +2666,7 @@ where
 
     fn boxed<'c>(self) -> Boxed<'src, 'c, I, O, E>
     where
-        Self: MaybeSync + Sized + 'src + 'c,
+        Self: Sized + 'src + 'c,
     {
         // Never double-box parsers
         self
@@ -3331,41 +3306,6 @@ mod tests {
     fn todo_err() {
         let expr = todo::<&str, String, extra::Default>();
         expr.then_ignore(end()).parse("a+b+c");
-    }
-
-    #[test]
-    fn arc_impl() {
-        use alloc::sync::Arc;
-
-        fn parser<'src>() -> impl Parser<'src, &'src str, Vec<u64>> {
-            Arc::new(
-                any()
-                    .filter(|c: &char| c.is_ascii_digit())
-                    .repeated()
-                    .at_least(1)
-                    .at_most(3)
-                    .to_slice()
-                    .map(|b: &str| b.parse::<u64>().unwrap())
-                    .padded()
-                    .separated_by(just(',').padded())
-                    .allow_trailing()
-                    .collect()
-                    .delimited_by(just('['), just(']')),
-            )
-        }
-
-        assert_eq!(
-            parser().parse("[122 , 23,43,    4, ]").into_result(),
-            Ok(vec![122, 23, 43, 4]),
-        );
-        assert_eq!(
-            parser().parse("[0, 3, 6, 900,120]").into_result(),
-            Ok(vec![0, 3, 6, 900, 120]),
-        );
-        assert_eq!(
-            parser().parse("[200,400,50  ,0,0, ]").into_result(),
-            Ok(vec![200, 400, 50, 0, 0]),
-        );
     }
 
     #[test]

--- a/src/pratt.rs
+++ b/src/pratt.rs
@@ -195,9 +195,9 @@ where
     /// Box this operator, allowing it to be used via dynamic dispatch.
     fn boxed<'a>(self) -> Boxed<'src, 'a, I, O, E>
     where
-        Self: Sized + MaybeSync + 'a,
+        Self: Sized + 'a,
     {
-        Boxed(RefC::new(self))
+        Boxed(Rc::new(self))
     }
 
     #[doc(hidden)]
@@ -307,7 +307,7 @@ where
 }
 
 /// A boxed pratt parser operator. See [`Operator`].
-pub struct Boxed<'src, 'a, I, O, E>(RefC<sync::DynOperator<'src, 'a, I, O, E>>);
+pub struct Boxed<'src, 'a, I, O, E>(Rc<DynOperator<'src, 'a, I, O, E>>);
 
 impl<I, O, E> Clone for Boxed<'_, '_, I, O, E> {
     fn clone(&self) -> Self {

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -215,8 +215,8 @@ pub fn nested_delimiters<'src, I, O, E, F, const N: usize>(
 ) -> impl Parser<'src, I, O, E> + Clone
 where
     I: ValueInput<'src>,
-    I::Token: PartialEq + Clone + MaybeSync,
-    E: extra::ParserExtra<'src, I> + MaybeSync,
+    I::Token: PartialEq + Clone,
+    E: extra::ParserExtra<'src, I>,
     F: Fn(I::Span) -> O + Clone,
 {
     // TODO: Does this actually work? TESTS!

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,8 +7,6 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-pub use sync::MaybeSync;
-
 /// A value that may be a `T` or a mutable reference to a `T`.
 pub type MaybeMut<'a, T> = Maybe<T, &'a mut T>;
 


### PR DESCRIPTION
`sync` has been broken for a while, and does not respective the additive nature of cargo features. This PR removes it until a better solution can be found.

If you depended on `sync`:

- Sorry
- Information about what exactly your use-case looks like so that a better replacement can be found would be useful!