### PR TITLE
Fix some holes in documentation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -86,6 +86,17 @@ pub trait Error<'a, I: Input<'a>>:
 
 /// A ZST error type that tracks only whether a parse error occurred at all. This type is for when
 /// you want maximum parse speed, at the cost of all error reporting.
+///
+/// # Examples
+/// 
+/// ```
+/// use chumsky::prelude::*;
+/// 
+/// let parser = just::<_, _, extra::Err<EmptyErr>>("valid");
+/// let error = parser.parse("invalid").into_errors()[0];
+/// 
+/// assert_eq!(error, EmptyErr::default());
+/// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone, Default)]
 pub struct EmptyErr(());
@@ -111,6 +122,17 @@ impl fmt::Display for EmptyErr {
 
 /// A very cheap error type that tracks only the error span. This type is most useful when you want fast parsing but do
 /// not particularly care about the quality of error messages.
+///
+/// # Examples
+/// 
+/// ```
+/// use chumsky::prelude::*;
+/// 
+/// let parser = just::<_, _, extra::Err<Cheap>>("+");
+/// let error = parser.parse("-").into_errors()[0];
+/// 
+/// assert_eq!(error.span(), &SimpleSpan::new(0,1));
+/// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Cheap<S = SimpleSpan<usize>> {
@@ -158,6 +180,18 @@ where
 
 /// A simple error type that tracks the error span and found token. This type is most useful when you want fast parsing
 /// but do not particularly care about the quality of error messages.
+///
+/// # Examples
+/// 
+/// ```
+/// use chumsky::prelude::*;
+/// 
+/// let parser = just::<_, _, extra::Err<Simple<char>>>("+");
+/// let error = parser.parse("-").into_errors()[0];
+/// 
+/// assert_eq!(error.span(), &SimpleSpan::new(0,1));
+/// assert_eq!(error.found(), Some(&'-'));
+/// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Simple<'a, T, S = SimpleSpan<usize>> {
@@ -537,6 +571,21 @@ where
 ///
 /// Please note that it uses a [`Vec`] to remember expected symbols. If you find this to be too slow, you can
 /// implement [`Error`] for your own error type or use [`Simple`] instead.
+///
+/// # Examples
+/// 
+/// ```
+/// use chumsky::prelude::*;
+/// use chumsky::error::{RichReason, RichPattern};
+/// 
+/// let parser = one_of::<_, _, extra::Err<Rich<char>>>("1234");
+/// let error = parser.parse("5").into_errors()[0].clone();
+/// 
+/// assert_eq!(error.span(), &SimpleSpan::new(0,1));
+/// assert!(matches!(error.reason(), &RichReason::ExpectedFound {..}));
+/// assert_eq!(error.found(), Some(&'5'));
+/// 
+/// ```
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Rich<'a, T, S = SimpleSpan<usize>> {
     span: S,

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,13 +88,13 @@ pub trait Error<'a, I: Input<'a>>:
 /// you want maximum parse speed, at the cost of all error reporting.
 ///
 /// # Examples
-/// 
+///
 /// ```
 /// use chumsky::prelude::*;
-/// 
+///
 /// let parser = just::<_, _, extra::Err<EmptyErr>>("valid");
 /// let error = parser.parse("invalid").into_errors()[0];
-/// 
+///
 /// assert_eq!(error, EmptyErr::default());
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -120,17 +120,17 @@ impl fmt::Display for EmptyErr {
     }
 }
 
-/// A very cheap error type that tracks only the error span ([`SimpleSpan`] by default). 
+/// A very cheap error type that tracks only the error span ([`SimpleSpan`] by default).
 /// This type is most useful when you want fast parsing but do not particularly care about the quality of error messages.
 ///
 /// # Examples
-/// 
+///
 /// ```
 /// use chumsky::prelude::*;
-/// 
+///
 /// let parser = just::<_, _, extra::Err<Cheap>>("+");
 /// let error = parser.parse("-").into_errors()[0];
-/// 
+///
 /// assert_eq!(error.span(), &SimpleSpan::new(0,1));
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -141,7 +141,7 @@ pub struct Cheap<S = SimpleSpan<usize>> {
 
 impl<S> Cheap<S> {
     /// Get the span than that error related to.
-    /// 
+    ///
     /// If the span type is unspecified, it is [`SimpleSpan`].
     pub fn span(&self) -> &S {
         &self.span
@@ -184,13 +184,13 @@ where
 /// but do not particularly care about the quality of error messages.
 ///
 /// # Examples
-/// 
+///
 /// ```
 /// use chumsky::prelude::*;
-/// 
+///
 /// let parser = just::<_, _, extra::Err<Simple<char>>>("+");
 /// let error = parser.parse("-").into_errors()[0];
-/// 
+///
 /// assert_eq!(error.span(), &SimpleSpan::new(0,1));
 /// assert_eq!(error.found(), Some(&'-'));
 /// ```
@@ -203,7 +203,7 @@ pub struct Simple<'a, T, S = SimpleSpan<usize>> {
 
 impl<T, S> Simple<'_, T, S> {
     /// Get the span than that error related to.
-    /// 
+    ///
     /// If the span type is unspecified, it is [`SimpleSpan`].
     pub fn span(&self) -> &S {
         &self.span
@@ -577,20 +577,20 @@ where
 /// implement [`Error`] for your own error type or use [`Simple`] instead.
 ///
 /// This error type stores a span ([`SimpleSpan`] by default), a [`RichReason`], and a list of expected [`RichPattern`] with their spans.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use chumsky::prelude::*;
 /// use chumsky::error::{RichReason, RichPattern};
-/// 
+///
 /// let parser = one_of::<_, _, extra::Err<Rich<char>>>("1234");
 /// let error = parser.parse("5").into_errors()[0].clone();
-/// 
+///
 /// assert_eq!(error.span(), &SimpleSpan::new(0,1));
 /// assert!(matches!(error.reason(), &RichReason::ExpectedFound {..}));
 /// assert_eq!(error.found(), Some(&'5'));
-/// 
+///
 /// ```
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Rich<'a, T, S = SimpleSpan<usize>> {
@@ -629,7 +629,7 @@ impl<'a, T, S> Rich<'a, T, S> {
     }
 
     /// Get the span associated with this error.
-    /// 
+    ///
     /// If the span type is unspecified, it is [`SimpleSpan`].
     pub fn span(&self) -> &S {
         &self.span

--- a/src/error.rs
+++ b/src/error.rs
@@ -209,7 +209,7 @@ impl<T, S> Simple<'_, T, S> {
         &self.span
     }
 
-    /// Get the token, if any, that was found at the error location.
+    /// Get the token found by this error when parsing. `None` implies that the error expected the end of input.
     pub fn found(&self) -> Option<&T> {
         self.found.as_deref()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,8 +120,8 @@ impl fmt::Display for EmptyErr {
     }
 }
 
-/// A very cheap error type that tracks only the error span. This type is most useful when you want fast parsing but do
-/// not particularly care about the quality of error messages.
+/// A very cheap error type that tracks only the error span ([`SimpleSpan`] by default). 
+/// This type is most useful when you want fast parsing but do not particularly care about the quality of error messages.
 ///
 /// # Examples
 /// 
@@ -141,6 +141,8 @@ pub struct Cheap<S = SimpleSpan<usize>> {
 
 impl<S> Cheap<S> {
     /// Get the span than that error related to.
+    /// 
+    /// If the span type is unspecified, it is [`SimpleSpan`].
     pub fn span(&self) -> &S {
         &self.span
     }
@@ -178,7 +180,7 @@ where
     }
 }
 
-/// A simple error type that tracks the error span and found token. This type is most useful when you want fast parsing
+/// A simple error type that tracks the error span ([`SimpleSpan`] by default) and found token. This type is most useful when you want fast parsing
 /// but do not particularly care about the quality of error messages.
 ///
 /// # Examples
@@ -201,6 +203,8 @@ pub struct Simple<'a, T, S = SimpleSpan<usize>> {
 
 impl<T, S> Simple<'_, T, S> {
     /// Get the span than that error related to.
+    /// 
+    /// If the span type is unspecified, it is [`SimpleSpan`].
     pub fn span(&self) -> &S {
         &self.span
     }
@@ -572,6 +576,8 @@ where
 /// Please note that it uses a [`Vec`] to remember expected symbols. If you find this to be too slow, you can
 /// implement [`Error`] for your own error type or use [`Simple`] instead.
 ///
+/// This error type stores a span ([`SimpleSpan`] by default), a [`RichReason`], and a list of expected [`RichPattern`] with their spans.
+/// 
 /// # Examples
 /// 
 /// ```
@@ -623,6 +629,8 @@ impl<'a, T, S> Rich<'a, T, S> {
     }
 
     /// Get the span associated with this error.
+    /// 
+    /// If the span type is unspecified, it is [`SimpleSpan`].
     pub fn span(&self) -> &S {
         &self.span
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2036,7 +2036,21 @@ pub trait Parser<'src, I: Input<'src>, O, E: ParserExtra<'src, I> = extra::Defau
     /// The resulting iterable parser will emit each element of the output type in turn.
     ///
     /// This is *broadly* analogous to functions like [`Vec::into_iter`], but operating at the level of parser outputs.
-    // TODO: Example
+    ///
+    /// # Examples
+    /// 
+    /// ```
+    /// use chumsky::prelude::*;
+    /// let letter = one_of::<_, _, extra::Err<Simple<char>>>("0123456789");
+    /// // Match a four digit number
+    /// let list = letter
+    ///     .repeated()
+    ///     .to_slice()
+    ///     .map(|string: &str| string.chars())
+    ///     .into_iter()
+    ///     .collect_exactly::<[char; 4]>();
+    /// assert_eq!(list.parse("1235").unwrap(), ['1', '2', '3', '5']);
+    /// ```
     fn into_iter(self) -> IntoIter<Self, O>
     where
         Self: Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,6 +452,34 @@ pub trait Parser<'src, I: Input<'src>, O, E: ParserExtra<'src, I> = extra::Defau
 
     /// Convert the output of this parser into a slice of the input, based on the current parser's
     /// span.
+    ///
+    /// Note: unlike the parser `.repeated().collect()`, this method includes all tokens that are 
+    /// "ignored" by the parser, including any padding, separators, and sub-parsers with 
+    /// [`Parser::ignored`], [`Parser::ignore_then`], and [`Parser::then_ignore`].
+    ///
+    /// # Examples
+    /// Example with input of type `&str` (token type is `char`).
+    /// ```
+    /// # use chumsky::prelude::*;
+    /// // Matches a number with underscores that is surrounded by apostrophes.
+    /// let quoted_numeric = any::<&str, extra::Err<Simple<char>>>()
+    ///     .filter(|c: &char| c.is_digit(10))
+    ///     .separated_by(just("_").repeated().at_most(1))
+    ///     .to_slice()
+    ///     .padded_by(just("'"));
+    /// assert_eq!(quoted_numeric.parse("'1_23'").into_result(), Ok("1_23"));
+    /// ```
+    /// Example with input of type `&[u32]` (token type is `u32`).
+    /// ```
+    /// # use chumsky::prelude::*;
+    /// // Matches even numbers, then ignoring the rest of the input when an odd number is reached.
+    /// let even_matcher = any::<&[u32], extra::Err<Simple<u32>>>()
+    ///     .filter(|c: &u32| c % 2 == 0)
+    ///     .repeated()
+    ///     .to_slice()
+    ///     .lazy();
+    /// assert_eq!(even_matcher.parse(&[2, 4, 8, 5, 6]).unwrap(), &[2, 4, 8]);
+    /// ```
     fn to_slice(self) -> ToSlice<Self, O>
     where
         Self: Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2068,16 +2068,19 @@ pub trait Parser<'src, I: Input<'src>, O, E: ParserExtra<'src, I> = extra::Defau
     /// # Examples
     ///
     /// ```
-    /// use chumsky::prelude::*;
-    /// let letter = one_of::<_, _, extra::Err<Simple<char>>>("0123456789");
-    /// // Match a four digit number
-    /// let list = letter
-    ///     .repeated()
-    ///     .to_slice()
-    ///     .map(|string: &str| string.chars())
+    /// # use chumsky::prelude::*;
+    /// // Parses whole integers
+    /// let num = text::int::<&str, extra::Default>(10).padded().map(|x: &str| x.parse::<u64>().unwrap());
+    /// // Parses a range like `0..4` into a vector like `[0, 1, 2, 3]`
+    /// let range = num.then_ignore(just("..")).then(num)
+    ///     .map(|(x, y)| x..y)
     ///     .into_iter()
-    ///     .collect_exactly::<[char; 4]>();
-    /// assert_eq!(list.parse("1235").unwrap(), ['1', '2', '3', '5']);
+    ///     .collect::<Vec<u64>>();
+    /// // Parses a list of numbers into a vector
+    /// let list = num.separated_by(just(',')).collect::<Vec<u64>>();
+    /// let set = range.or(list);
+    /// assert_eq!(set.parse("0, 1, 2, 3").unwrap(), [0, 1, 2, 3]);
+    /// assert_eq!(set.parse("0..4").unwrap(), [0, 1, 2, 3]);
     /// ```
     fn into_iter(self) -> IntoIter<Self, O>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,8 +453,8 @@ pub trait Parser<'src, I: Input<'src>, O, E: ParserExtra<'src, I> = extra::Defau
     /// Convert the output of this parser into a slice of the input, based on the current parser's
     /// span.
     ///
-    /// Note: unlike the parser `.repeated().collect()`, this method includes all tokens that are 
-    /// "ignored" by the parser, including any padding, separators, and sub-parsers with 
+    /// Note: unlike the parser `.repeated().collect()`, this method includes all tokens that are
+    /// "ignored" by the parser, including any padding, separators, and sub-parsers with
     /// [`Parser::ignored`], [`Parser::ignore_then`], and [`Parser::then_ignore`].
     ///
     /// # Examples
@@ -2066,7 +2066,7 @@ pub trait Parser<'src, I: Input<'src>, O, E: ParserExtra<'src, I> = extra::Defau
     /// This is *broadly* analogous to functions like [`Vec::into_iter`], but operating at the level of parser outputs.
     ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use chumsky::prelude::*;
     /// let letter = one_of::<_, _, extra::Err<Simple<char>>>("0123456789");


### PR DESCRIPTION
Hello!

Added some missing documentation, mostly examples and filling in holes in the error module.

Change list:
- Added examples to error::EmptyError, error::Cheap, error::Simple, Error::Rich
- Added examples to Parser::into_iter, Parser::to_slice
- Added note comparing IterParser::Collect and Parser::to_slice on including/excluding ignored patterns.
- Added links to relevant attribute types in errors
  - It wasn't really clear what error::Rich was storing, especially that the links to RichPattern and RichReason were buried in method headers below, so I thought it would be good to add links to those.
  - It also wasn't clear what the return type of each of the "span" methods was, since they all said they returned "&S", but for some reason, cargo doc linked to [https://doc.rust-lang.org/std/primitive.reference.html](https://doc.rust-lang.org/std/primitive.reference.html) :sob:
- Fixed inconsistency between docs on Simple::found and Rich::found

Let me know if I should make any changes