### PR TITLE
Fix SimpleSpan method headers

### DIFF
--- a/examples/nested_spans.rs
+++ b/examples/nested_spans.rs
@@ -49,17 +49,17 @@ fn main() {
     let tokens = [
         (
             Token::Parens(vec![
-                (Token::Num(2), SimpleSpan::new(1, 2)),
-                (Token::Add, SimpleSpan::new(3, 4)),
-                (Token::Num(3), SimpleSpan::new(5, 6)),
+                (Token::Num(2), SimpleSpan::new((), 1..2)),
+                (Token::Add, SimpleSpan::new((), 3..4)),
+                (Token::Num(3), SimpleSpan::new((), 5..6)),
             ]),
-            SimpleSpan::new(0, 7),
+            SimpleSpan::new((), 0..7),
         ),
-        (Token::Mul, SimpleSpan::new(8, 9)),
-        (Token::Num(4), SimpleSpan::new(10, 11)),
+        (Token::Mul, SimpleSpan::new((), 8..9)),
+        (Token::Num(4), SimpleSpan::new((), 10..11)),
     ];
 
-    let eoi = SimpleSpan::new(11, 11); // Example EoI
+    let eoi = SimpleSpan::new((), 11..11); // Example EoI
 
     assert_eq!(
         parser(make_input)

--- a/src/span.rs
+++ b/src/span.rs
@@ -94,15 +94,6 @@ pub struct SimpleSpan<T = usize, C = ()> {
     context: C,
 }
 
-impl<T: Clone, C: Clone> SimpleSpan<T, C> {
-    /// Create a new `SimpleSpan` from a single offset, useful for an EOI (End Of Input) span.
-    ///
-    /// Context is the unit type `()` by default.
-    pub fn splat(context: C, offset: T) -> SimpleSpan<T, C> {
-        Self::new(context, offset.clone()..offset)
-    }
-}
-
 impl<T, C> SimpleSpan<T, C> {
     /// Convert this span into a [`std::ops::Range`].
     pub fn into_range(self) -> Range<T> {

--- a/src/span.rs
+++ b/src/span.rs
@@ -103,7 +103,7 @@ impl<T: Clone, C: Clone> SimpleSpan<T, C> {
     }
 }
 
-impl<T> SimpleSpan<T> {
+impl<T, C> SimpleSpan<T, C> {
     /// Convert this span into a [`std::ops::Range`].
     pub fn into_range(self) -> Range<T> {
         self.into()
@@ -120,8 +120,8 @@ impl<T> From<Range<T>> for SimpleSpan<T> {
     }
 }
 
-impl<T> From<SimpleSpan<T>> for Range<T> {
-    fn from(span: SimpleSpan<T>) -> Self {
+impl<T, C> From<SimpleSpan<T, C>> for Range<T> {
+    fn from(span: SimpleSpan<T, C>) -> Self {
         Range {
             start: span.start,
             end: span.end,
@@ -147,7 +147,7 @@ where
     }
 }
 
-impl<T> IntoIterator for SimpleSpan<T>
+impl<T, C> IntoIterator for SimpleSpan<T, C>
 where
     Range<T>: Iterator<Item = T>,
 {

--- a/src/span.rs
+++ b/src/span.rs
@@ -94,24 +94,16 @@ pub struct SimpleSpan<T = usize, C = ()> {
     context: C,
 }
 
-impl<T> SimpleSpan<T> {
-    /// Create a new `SimpleSpan` from a start and end offset
-    pub fn new(start: T, end: T) -> SimpleSpan<T> {
-        SimpleSpan {
-            start,
-            end,
-            context: (),
-        }
-    }
-
+impl<T: Clone, C: Clone> SimpleSpan<T, C> {
     /// Create a new `SimpleSpan` from a single offset, useful for an EOI (End Of Input) span.
-    pub fn splat(offset: T) -> SimpleSpan<T>
-    where
-        T: Clone,
-    {
-        Self::new(offset.clone(), offset)
+    ///
+    /// Context is the unit type `()` by default.
+    pub fn splat(context: C, offset: T) -> SimpleSpan<T, C> {
+        Self::new(context, offset.clone()..offset)
     }
+}
 
+impl<T> SimpleSpan<T> {
     /// Convert this span into a [`std::ops::Range`].
     pub fn into_range(self) -> Range<T> {
         self.into()

--- a/src/span.rs
+++ b/src/span.rs
@@ -97,7 +97,7 @@ pub struct SimpleSpan<T = usize, C = ()> {
 impl<T, C> SimpleSpan<T, C> {
     /// Convert this span into a [`std::ops::Range`].
     pub fn into_range(self) -> Range<T> {
-        self.into()
+        self.start..self.end
     }
 }
 
@@ -111,8 +111,8 @@ impl<T> From<Range<T>> for SimpleSpan<T> {
     }
 }
 
-impl<T, C> From<SimpleSpan<T, C>> for Range<T> {
-    fn from(span: SimpleSpan<T, C>) -> Self {
+impl<T> From<SimpleSpan<T, ()>> for Range<T> {
+    fn from(span: SimpleSpan<T>) -> Self {
         Range {
             start: span.start,
             end: span.end,
@@ -146,7 +146,7 @@ where
     type Item = T;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.into()
+        self.start..self.end
     }
 }
 


### PR DESCRIPTION
Changelog
- Remove SimpleSpan::new, which can be replaced with <SimpleSpan as Span>::new
- Remove SimpleSpan::splat
- Update SimpleSpan into range or into iterator to support contexts

Fixes: #719 