### PR TITLE
Attempt At Non-Infix Pratt Parsing

### DIFF
--- a/src/pratt.rs
+++ b/src/pratt.rs
@@ -435,9 +435,18 @@ where
 }
 
 /// Defines the [associativity](https://en.wikipedia.org/wiki/Associative_property) and binding power of an [`infix`]
-/// operator (see [`left`] and [`right`]).
+/// operator (see [`left`], [`right`], and [`non`]).
 ///
 /// Higher binding powers should be used for higher precedence operators.
+///
+/// The left, right, and next binding powers are used to determine precedence in the parser. They
+/// are calculated as follows:
+///
+/// |       | left power | right power | next power |
+/// |-------|------------|-------------|------------|
+/// | Left  | bp * 3     | bp * 3 + 1  | bp * 3     |
+/// | Right | bp * 3 + 1 | bp * 3      | bp * 3     |
+/// | Non   | bp * 3     | bp * 3      | bp * 3 + 1 |
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Associativity {
     /// Specifies that the operator should be left-associative, with the given binding power (see [`left`]).
@@ -476,17 +485,22 @@ pub fn non(binding_power: u16) -> Associativity {
 impl Associativity {
     fn left_power(&self) -> u32 {
         match self {
-            Self::Left(x) => *x as u32 * 2,
-            Self::Right(x) => *x as u32 * 2 + 1,
-            Self::Non(x) => todo!(),
+            &Self::Left(x) | &Self::Non(x) => x as u32 * 3,
+            &Self::Right(x) => x as u32 * 3 + 1,
         }
     }
 
     fn right_power(&self) -> u32 {
         match self {
-            Self::Left(x) => *x as u32 * 2 + 1,
-            Self::Right(x) => *x as u32 * 2,
-            Self::Non(x) => todo!()
+            &Self::Right(x) | &Self::Non(x) => x as u32 * 3,
+            &Self::Left(x) => x as u32 * 3 + 1,
+        }
+    }
+
+    fn next_power(&self) -> u32 {
+        match self {
+            &Self::Left(x) | &Self::Right(x) => x as u32 * 3,
+            &Self::Non(x) => x as u32 * 3 + 1,
         }
     }
 }

--- a/src/pratt.rs
+++ b/src/pratt.rs
@@ -595,12 +595,7 @@ where
             }
         };
 
-        let next_power = match assoc {
-            Associativity::Non(_) => assoc.next_power(),
-            _ => assoc.right_power(),
-        };
-
-        let rhs = match f(inp, next_power) {
+        let rhs = match f(inp, assoc.right_power()) {
             Ok(rhs) => rhs,
             Err(()) => {
                 inp.rewind(pre_op.clone());
@@ -1317,6 +1312,10 @@ mod tests {
                 infix(non(2), just('*'), |l, _, r, _| i(Expr::Mul, l, r)),
             ))
             .map(|x| x.to_string());
-        assert!(parser.parse("1+2*3*3").has_errors())
+        assert_eq!(
+            parser.parse("1+2*3").into_result(),
+            Ok("(1 + (2 * 3))".to_string())
+        );
+        assert!(parser.parse("1+2*3*3").has_errors());
     }
 }

--- a/src/pratt.rs
+++ b/src/pratt.rs
@@ -444,6 +444,8 @@ pub enum Associativity {
     Left(u16),
     /// Specifies that the operator should be right-associative, with the given binding power (see [`right`]).
     Right(u16),
+    /// Specifies that the operator should non-associative, with the given binding power (see [`non`]).
+    Non(u16),
 }
 
 /// Specifies a left [`Associativity`] with the given binding power.
@@ -462,11 +464,21 @@ pub fn right(binding_power: u16) -> Associativity {
     Associativity::Right(binding_power)
 }
 
+/// Specifies a non-associative [`Associativity`] with the given binding power.
+///
+/// Non-associative operators cannot be chained, but otherwise respect binding powers. For example,
+/// the expression `a == b == c` is invalid if `==` is a non-associative operator (which in
+/// general, all comparison operators are).
+pub fn non(binding_power: u16) -> Associativity {
+    Associativity::Non(binding_power)
+}
+
 impl Associativity {
     fn left_power(&self) -> u32 {
         match self {
             Self::Left(x) => *x as u32 * 2,
             Self::Right(x) => *x as u32 * 2 + 1,
+            Self::Non(x) => todo!(),
         }
     }
 
@@ -474,6 +486,7 @@ impl Associativity {
         match self {
             Self::Left(x) => *x as u32 * 2 + 1,
             Self::Right(x) => *x as u32 * 2,
+            Self::Non(x) => todo!()
         }
     }
 }
@@ -536,7 +549,6 @@ where
     A: Parser<'src, I, Op, E>,
     F: Fn(O, Op, O, &mut MapExtra<'src, '_, I, E>) -> O,
 {
-    #[inline]
     fn do_parse_infix<'parse, M: Mode>(
         &self,
         inp: &mut InputRef<'src, 'parse, I, E>,

--- a/src/private.rs
+++ b/src/private.rs
@@ -108,6 +108,7 @@ pub trait Mode {
         pre_op: &input::Checkpoint<'src, 'parse, I, <E::State as Inspector<'src, I>>::Checkpoint>,
         lhs: Self::Output<O>,
         min_power: u32,
+        max_power: &mut u32,
         f: &impl Fn(&mut InputRef<'src, 'parse, I, E>, u32) -> PResult<Self, O>,
     ) -> Result<Self::Output<O>, Self::Output<O>>
     where
@@ -228,6 +229,7 @@ impl Mode for Emit {
         pre_op: &input::Checkpoint<'src, 'parse, I, <E::State as Inspector<'src, I>>::Checkpoint>,
         lhs: Self::Output<O>,
         min_power: u32,
+        max_power: &mut u32,
         f: &impl Fn(&mut InputRef<'src, 'parse, I, E>, u32) -> PResult<Self, O>,
     ) -> Result<Self::Output<O>, Self::Output<O>>
     where
@@ -235,7 +237,7 @@ impl Mode for Emit {
         I: Input<'src>,
         E: ParserExtra<'src, I>,
     {
-        op.do_parse_infix_emit(inp, pre_expr, pre_op, lhs, min_power, &f)
+        op.do_parse_infix_emit(inp, pre_expr, pre_op, lhs, min_power, max_power, &f)
     }
 }
 
@@ -339,6 +341,7 @@ impl Mode for Check {
         pre_op: &input::Checkpoint<'src, 'parse, I, <E::State as Inspector<'src, I>>::Checkpoint>,
         lhs: Self::Output<O>,
         min_power: u32,
+        max_power: &mut u32,
         f: &impl Fn(&mut InputRef<'src, 'parse, I, E>, u32) -> PResult<Self, O>,
     ) -> Result<Self::Output<O>, Self::Output<O>>
     where
@@ -346,7 +349,7 @@ impl Mode for Check {
         I: Input<'src>,
         E: ParserExtra<'src, I>,
     {
-        op.do_parse_infix_check(inp, pre_expr, pre_op, lhs, min_power, &f)
+        op.do_parse_infix_check(inp, pre_expr, pre_op, lhs, min_power, max_power, &f)
     }
 }
 


### PR DESCRIPTION
Along the same lines as #600.

Currently, the `chumsky::pratt` parser only supports binary infix operators with `left` or `right` associativity, but not non-infix ones. Other libraries and literature might term this as `InfixN` or non-associative. (Please correct me if I'm wrong~)

For example, comparison operators like `>` and `==` are typically non-associative, since expressions like `1 == 2 == 3` is invalid. (They cannot be chained.)

This PR adds a `non` option for associativity, and tries to follow the same [article](https://www.engr.mun.ca/~theo/Misc/pratt_parsing.htm).