### PR TITLE
fix: text::ascii::ident won't accept numbers

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -540,7 +540,7 @@ pub mod ascii {
                 any()
                     .try_map(|c: I::Token, span| {
                         if c.to_ascii()
-                            .map_or(false, |i| i.is_ascii_alphabetic() || i == b'_')
+                            .map_or(false, |i| i.is_ascii_alphanumeric() || i == b'_')
                         {
                             Ok(())
                         } else {


### PR DESCRIPTION
text::ascii::ident() accepts only ascii alphabetic characters.

https://github.com/zesterer/chumsky/blob/d63e285bd56213d9c93a1ef24dddb5232cff07e6/src/text.rs#L543

`is_ascii_alphanumeric` should be used here

ae01819c667a0c857e6ed68cf12fc8c0ff71c977

In this commit, `is_ascii_alphanumeric` is changed to `is_ascii_alphabetic`

Closes #731 