### PR TITLE
Add a combinator `then_or_not` to optionally run a parser after another

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1957,6 +1957,31 @@ pub trait Parser<'src, I: Input<'src>, O, E: ParserExtra<'src, I> = extra::Defau
         }
     }
 
+    /// Parse another pattern if the current pattern succeeds.
+    ///
+    /// The output type of this parser is `Option<(O, U)>`, combining the outputs of both parsers if
+    /// the former succeed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use chumsky::prelude::*;
+    /// let range = text::int::<_, extra::Err<Simple<char>>>(10)
+    ///     .then(just("..").then_or_not(text::int(10)));
+    /// assert_eq!(range.parse("1..2").into_result(), Ok(("1", Some(("..", "2")))));
+    /// assert_eq!(range.parse("1").into_result(), Ok(("1", None)));
+    /// assert!(range.parse("1..").has_errors());
+    /// ```
+    fn then_or_not<U, B: Parser<'src, I, U, E>>(self, other: B) -> ThenOrNot<Self, B>
+    where
+        Self: Sized,
+    {
+        ThenOrNot {
+            parser_a: self,
+            parser_b: other,
+        }
+    }
+
     // /// Map the primary error of this parser to a result. If the result is [`Ok`], the parser succeeds with that value.
     // ///
     // /// Note that, if the closure returns [`Err`], the parser will not consume any input.


### PR DESCRIPTION
Closes #630, which first mentioned something like this.

This can be used in syntaxes like Rust's let statement, which has an optional type notation:

```rust
let a = 0;
let b: i32 = 0;
```

`.then(...).or_not()` doesn't work well in such cases, because when there's a parse error in the type, `or_not` would just suppress it and return `None`, leaving the following parsers confusing, or even worse, mistakenly starting parsing from the wrong position. In this particular example, when the type has an error, the parser may complain something like `expected '=', got ':'`, rather than pointing out the error in the type.

With `then_or_not`, Rust's let statement can roughly be parsed with:

```rust
let let_stmt = group((
        just("let").padded(),
        pattern,
        just(':').padded().then_or_not(rust_type),
        just('=').padded().then_or_not(expr),
    ))
    .map(|(_, pat, ty, val)| Stmt::Let(pat, ty.map(|t| t.1), val.map(|v| v.1)));
```

And this would correctly report the errors in `rust_type` and `expr`.

