### PR TITLE
Update Ariadne to 0.5.1 and fix examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,9 +71,9 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "ariadne"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367fd0ad87307588d087544707bc5fbf4805ded96c7db922b70d368fa1cb5702"
+checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
 dependencies = [
  "unicode-width",
  "yansi",
@@ -2506,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ bytes = { version = "1", default-features = false, optional = true }
 vergen-gix = { version = "1.0", optional = true, features = ["emit_and_set"] }
 
 [dev-dependencies]
-ariadne = "0.2"
+ariadne = "0.5.1"
 pom = "3.2"
 nom = "7.1"
 winnow = "0.7.0"

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -142,10 +142,10 @@ fn main() {
     let (json, errs) = parser().parse(src.trim()).into_output_errors();
     println!("{:#?}", json);
     errs.into_iter().for_each(|e| {
-        Report::build(ReportKind::Error, (), e.span().start)
+        Report::build(ReportKind::Error, ((), e.span().into_range()))
             .with_message(e.to_string())
             .with_label(
-                Label::new(e.span().into_range())
+                Label::new(((), e.span().into_range()))
                     .with_message(e.reason().to_string())
                     .with_color(Color::Red),
             )

--- a/examples/logos.rs
+++ b/examples/logos.rs
@@ -156,11 +156,11 @@ fn main() {
         // with Rust's built-in `Display` trait, but it's a little crude
         Err(errs) => {
             for err in errs {
-                Report::build(ReportKind::Error, (), err.span().start)
+                Report::build(ReportKind::Error, ((), err.span().into_range()))
                     .with_code(3)
                     .with_message(err.to_string())
                     .with_label(
-                        Label::new(err.span().into_range())
+                        Label::new(((), err.span().into_range()))
                             .with_message(err.reason().to_string())
                             .with_color(Color::Red),
                     )

--- a/examples/mini_ml.rs
+++ b/examples/mini_ml.rs
@@ -411,7 +411,7 @@ fn failure(
     src: &str,
 ) -> ! {
     let fname = "example";
-    Report::build(ReportKind::Error, fname, label.1.start)
+    Report::build(ReportKind::Error, (fname, label.1.into_range()))
         .with_message(&msg)
         .with_label(
             Label::new((fname, label.1.into_range()))

--- a/examples/nano_rust.rs
+++ b/examples/nano_rust.rs
@@ -599,7 +599,7 @@ fn main() {
                 .map(|e| e.map_token(|tok| tok.to_string())),
         )
         .for_each(|e| {
-            Report::build(ReportKind::Error, filename.clone(), e.span().start)
+            Report::build(ReportKind::Error, (filename.clone(), e.span().into_range()))
                 .with_message(e.to_string())
                 .with_label(
                     Label::new((filename.clone(), e.span().into_range()))


### PR DESCRIPTION
When trying to use the code snippets from the examples with a more recent version of `ariadne`, I encountered compilation errors due to API changes between Ariadne v0.2 and later versions (specifically v0.3+). This can be confusing for users trying to learn the library or adapt the examples. Keeping the examples aligned with a recent version of `ariadne` improves the developer experience.

This also addresses issue #714, which requested updating the examples for Ariadne 0.5.

**Changes:**

*   Updated `ariadne` in `Cargo.toml` (dev-dependencies) and `Cargo.lock` to `0.5.1`.
*   Modified all examples (`examples/*.rs`) to use the updated `ariadne` API, specifically:
    *   `Report::build` now takes `(SourceId, Span)` instead of `SourceId, Offset`.
    *   `Label::new` now takes `(SourceId, Span)` instead of just `Span`.

I've confirmed that the examples build and run correctly with these changes.

Fixes #714