### PR TITLE
added nom8 benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,8 @@ dependencies = [
  "lasso",
  "lexical",
  "logos",
- "nom",
+ "nom 7.1.3",
+ "nom 8.0.0",
  "pest",
  "pest_derive",
  "pom",
@@ -769,6 +770,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ bytes = { version = "1", default-features = false, optional = true }
 ariadne = "0.5"
 pom = "3.2"
 nom = "7.1"
+nom8 = { package = "nom", version = "8"}
 winnow = "0.7.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 ciborium = { version = "0.2" }

--- a/benches/cbor.rs
+++ b/benches/cbor.rs
@@ -312,7 +312,10 @@ mod nom {
 mod nom8 {
     use super::CborZero;
     use nom8::{
-        bits::{bits, bytes, complete::{tag, take}},
+        bits::{
+            bits, bytes,
+            complete::{tag, take},
+        },
         branch::alt,
         bytes::complete::take as take_bytes,
         combinator::{map, value as to, verify},
@@ -329,21 +332,24 @@ mod nom8 {
             preceded(tag(25, 5usize), take(16usize)),
             preceded(tag(26, 5usize), take(32usize)),
             preceded(tag(27, 5usize), take(64usize)),
-        )).parse_complete(i)
+        ))
+        .parse_complete(i)
     }
 
     fn uint<'a>(i: &[u8]) -> IResult<&[u8], CborZero<'a>> {
         bits(preceded(
             tag(0, 3usize),
             map(integer, |v| CborZero::Int(v.try_into().unwrap())),
-        )).parse_complete(i)
+        ))
+        .parse_complete(i)
     }
 
     fn nint<'a>(i: &[u8]) -> IResult<&[u8], CborZero<'a>> {
         bits(preceded(
             tag(1, 3usize),
             map(integer, |v| CborZero::Int(-1 - i64::try_from(v).unwrap())),
-        )).parse_complete(i)
+        ))
+        .parse_complete(i)
     }
 
     fn bstr(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {
@@ -405,7 +411,8 @@ mod nom8 {
                     }),
                 ),
             )),
-        )).parse_complete(i)
+        ))
+        .parse_complete(i)
     }
 
     fn value(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {
@@ -418,7 +425,8 @@ mod nom8 {
             cbor_map,
             cbor_tag,
             float_simple,
-        )).parse_complete(i)
+        ))
+        .parse_complete(i)
     }
 
     pub fn cbor(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {

--- a/benches/cbor.rs
+++ b/benches/cbor.rs
@@ -9,6 +9,10 @@ fn bench_cbor(c: &mut Criterion) {
         move |b| b.iter(|| black_box(nom::cbor(black_box(CBOR)).unwrap()))
     });
 
+    c.bench_function("cbor_nom8", {
+        move |b| b.iter(|| black_box(nom8::cbor(black_box(CBOR)).unwrap()))
+    });
+
     // c.bench_function("cbor_winnow", {
     //     move |b| b.iter(|| black_box(winnow::cbor(black_box(JSON)).unwrap()))
     // });
@@ -298,6 +302,123 @@ mod nom {
             cbor_tag,
             float_simple,
         ))(i)
+    }
+
+    pub fn cbor(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {
+        value(i)
+    }
+}
+
+mod nom8 {
+    use super::CborZero;
+    use nom8::{
+        bits::{bits, bytes, complete::{tag, take}},
+        branch::alt,
+        bytes::complete::take as take_bytes,
+        combinator::{map, value as to, verify},
+        multi::count,
+        number::complete::{be_f32, be_f64},
+        sequence::{pair, preceded},
+        IResult, Parser,
+    };
+
+    fn integer(i: (&[u8], usize)) -> IResult<(&[u8], usize), u64> {
+        alt((
+            verify(take(5usize), |&v| v < 24),
+            preceded(tag(24, 5usize), take(8usize)),
+            preceded(tag(25, 5usize), take(16usize)),
+            preceded(tag(26, 5usize), take(32usize)),
+            preceded(tag(27, 5usize), take(64usize)),
+        )).parse_complete(i)
+    }
+
+    fn uint<'a>(i: &[u8]) -> IResult<&[u8], CborZero<'a>> {
+        bits(preceded(
+            tag(0, 3usize),
+            map(integer, |v| CborZero::Int(v.try_into().unwrap())),
+        )).parse_complete(i)
+    }
+
+    fn nint<'a>(i: &[u8]) -> IResult<&[u8], CborZero<'a>> {
+        bits(preceded(
+            tag(1, 3usize),
+            map(integer, |v| CborZero::Int(-1 - i64::try_from(v).unwrap())),
+        )).parse_complete(i)
+    }
+
+    fn bstr(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {
+        // TODO: Handle indefinite length
+        let (i, length) = bits(preceded(tag(2, 3usize), integer)).parse_complete(i)?;
+        let length = usize::try_from(length).unwrap();
+        let (i, data) = take_bytes(length).parse_complete(i)?;
+        Ok((i, CborZero::Bytes(data)))
+    }
+
+    fn str(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {
+        // TODO: Handle indefinite length
+        let (i, length) = bits(preceded(tag(3, 3usize), integer)).parse_complete(i)?;
+        let length = usize::try_from(length).unwrap();
+        let (i, data) = take_bytes(length).parse_complete(i)?;
+        Ok((i, CborZero::String(std::str::from_utf8(data).unwrap())))
+    }
+
+    fn array(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {
+        // TODO: Handle indefinite length
+        let (i, length) = bits(preceded(tag(4, 3usize), integer)).parse_complete(i)?;
+        let (i, data) = count(value, length as usize).parse_complete(i)?;
+        Ok((i, CborZero::Array(data)))
+    }
+
+    fn cbor_map(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {
+        // TODO: Handle indefinite length
+        let (i, length) = bits(preceded(tag(5, 3usize), integer))(i)?;
+        let (i, data) = count(pair(value, value), length as usize).parse_complete(i)?;
+        Ok((i, CborZero::Map(data)))
+    }
+
+    fn cbor_tag(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {
+        let (i, tag) = bits(preceded(tag(6, 3usize), integer))(i)?;
+        let (i, value) = value(i)?;
+        Ok((i, CborZero::Tag(tag, Box::new(value))))
+    }
+
+    fn float_simple(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {
+        bits(preceded(
+            tag(7, 3usize),
+            alt((
+                to(CborZero::Bool(false), tag(20, 5usize)),
+                to(CborZero::Bool(true), tag(21, 5usize)),
+                to(CborZero::Null, tag(22, 5usize)),
+                to(CborZero::Undef, tag(23, 5usize)),
+                // preceded(tag(24, 5usize), ...), // u8
+                // preceded(tag(25, 5usize), map(be_f16, |v| CborZero::HalfFloat(v))),
+                preceded(
+                    tag(26, 5usize),
+                    map(bytes(be_f32::<_, nom8::error::Error<&[u8]>>), |v| {
+                        CborZero::SingleFloat(v)
+                    }),
+                ),
+                preceded(
+                    tag(27, 5usize),
+                    map(bytes(be_f64::<_, nom8::error::Error<&[u8]>>), |v| {
+                        CborZero::DoubleFloat(v)
+                    }),
+                ),
+            )),
+        )).parse_complete(i)
+    }
+
+    fn value(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {
+        alt((
+            uint,
+            nint,
+            bstr,
+            str,
+            array,
+            cbor_map,
+            cbor_tag,
+            float_simple,
+        )).parse_complete(i)
     }
 
     pub fn cbor(i: &[u8]) -> IResult<&[u8], CborZero<'_>> {


### PR DESCRIPTION
Hello.

I saw `nom` was still at 7, so I added `nom 8` as a separate bench for `cbor` and `json`. Didn't change the existing logic otherwise.