### PR TITLE
Make example token parser lifetimes more flexible

### DIFF
--- a/examples/logos.rs
+++ b/examples/logos.rs
@@ -71,9 +71,10 @@ enum SExpr {
 //     - Has an input type of type `I`, the one we declared as a type parameter
 //     - Produces an `SExpr` as its output
 //     - Uses `Rich`, a built-in error type provided by chumsky, for error generation
-fn parser<'a, I>() -> impl Parser<'a, I, SExpr, extra::Err<Rich<'a, Token<'a>>>>
+fn parser<'tokens, 'src: 'tokens, I>(
+) -> impl Parser<'tokens, I, SExpr, extra::Err<Rich<'tokens, Token<'src>>>>
 where
-    I: ValueInput<'a, Token = Token<'a>, Span = SimpleSpan>,
+    I: ValueInput<'tokens, Token = Token<'src>, Span = SimpleSpan>,
 {
     recursive(|sexpr| {
         let atom = select! {

--- a/examples/mini_ml.rs
+++ b/examples/mini_ml.rs
@@ -109,14 +109,14 @@ pub enum Expr<'src> {
     },
 }
 
-fn parser<'src, I, M>(
+fn parser<'tokens, 'src: 'tokens, I, M>(
     make_input: M,
-) -> impl Parser<'src, I, Spanned<Expr<'src>>, extra::Err<Rich<'src, Token<'src>>>>
+) -> impl Parser<'tokens, I, Spanned<Expr<'src>>, extra::Err<Rich<'tokens, Token<'src>>>>
 where
-    I: BorrowInput<'src, Token = Token<'src>, Span = SimpleSpan>,
+    I: BorrowInput<'tokens, Token = Token<'src>, Span = SimpleSpan>,
     // Because this function is generic over the input type, we need the caller to tell us how to create a new input,
     // `I`, from a nested token tree. This function serves that purpose.
-    M: Fn(SimpleSpan, &'src [Spanned<Token<'src>>]) -> I + Clone + 'src,
+    M: Fn(SimpleSpan, &'tokens [Spanned<Token<'src>>]) -> I + Clone + 'src,
 {
     recursive(|expr| {
         let ident = select_ref! { Token::Ident(x) => *x };

--- a/examples/nano_rust.rs
+++ b/examples/nano_rust.rs
@@ -178,10 +178,10 @@ struct Func<'src> {
     body: Spanned<Expr<'src>>,
 }
 
-fn expr_parser<'src, I>(
-) -> impl Parser<'src, I, Spanned<Expr<'src>>, extra::Err<Rich<'src, Token<'src>, Span>>> + Clone
+fn expr_parser<'tokens, 'src: 'tokens, I>(
+) -> impl Parser<'tokens, I, Spanned<Expr<'src>>, extra::Err<Rich<'tokens, Token<'src>, Span>>> + Clone
 where
-    I: ValueInput<'src, Token = Token<'src>, Span = Span>,
+    I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
 {
     recursive(|expr| {
         let inline_expr = recursive(|inline_expr| {
@@ -386,11 +386,14 @@ where
     })
 }
 
-fn funcs_parser<'src, I>(
-) -> impl Parser<'src, I, HashMap<&'src str, Func<'src>>, extra::Err<Rich<'src, Token<'src>, Span>>>
-       + Clone
+fn funcs_parser<'tokens, 'src: 'tokens, I>() -> impl Parser<
+    'tokens,
+    I,
+    HashMap<&'src str, Func<'src>>,
+    extra::Err<Rich<'tokens, Token<'src>, Span>>,
+> + Clone
 where
-    I: ValueInput<'src, Token = Token<'src>, Span = Span>,
+    I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
 {
     let ident = select! { Token::Ident(ident) => ident };
 


### PR DESCRIPTION
This splits the token and input src string lifetimes as shown in this issue: https://github.com/zesterer/chumsky/issues/747#issuecomment-2781473616. Wish I had found it sooner myself. :)