### PR TITLE
fix: generic changed from Container to OrderedSeq

### DIFF
--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -126,7 +126,7 @@ impl<T: Clone, I, E> Clone for Just<T, I, E> {
 
 /// A parser that accepts only the given input.
 ///
-/// The output type of this parser is `C`, the input or sequence that was provided.
+/// The output type of this parser is `T`, the input or sequence that was provided.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The generic name [used to be `C: Container<I>`](https://github.com/zesterer/chumsky/commit/b38db3e1e5ef6e94b690b08fdb77064d98ff3823) but it changed to `T: OrderedSeq<I::Token> + Clone`