### PR TITLE
fix: update the `filter` based on the experience of bugs related to `try_map`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDE projects
 .idea/
+.vscode/
 
 # Project output
 /target

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3813,6 +3813,33 @@ mod tests {
     }
 
     #[test]
+    fn filter() {
+        use crate::{DefaultExpected, LabelError};
+
+        let parser = group((
+            just("a").or_not(),
+            just("b").filter(|_| false).or_not(),
+            just::<_, &str, extra::Err<Rich<_>>>("c"),
+        ));
+
+        assert_eq!(
+            parser.parse("b").into_output_errors(),
+            (
+                None,
+                vec![LabelError::<&str, _>::expected_found(
+                    vec![
+                        DefaultExpected::Token('a'.into()),
+                        DefaultExpected::SomethingElse,
+                        DefaultExpected::Token('c'.into()),
+                    ],
+                    Some('b'.into()),
+                    SimpleSpan::new((), 0..1)
+                )]
+            )
+        );
+    }
+
+    #[test]
     fn zero_size_custom_failure() {
         fn my_custom<'src>() -> impl Parser<'src, &'src str, ()> {
             custom(|inp| {


### PR DESCRIPTION
The old `alt` is used.

Errors are given their corresponding location.

This also fixes #832.