### PR TITLE
fix: `rewind` generates incorrect errors (#843)

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -2758,13 +2758,25 @@ where
     #[inline(always)]
     fn go<M: Mode>(&self, inp: &mut InputRef<'src, '_, I, E>) -> PResult<M, O> {
         let before = inp.save();
-        match self.parser.go::<M>(inp) {
-            Ok(out) => {
-                inp.rewind(before);
-                Ok(out)
+        let old_alt = inp.take_alt();
+        let res = self.parser.go::<M>(inp);
+        let new_alt = inp.take_alt();
+
+        inp.errors.alt = old_alt;
+        if res.is_ok() {
+            if let Some(new_alt) = new_alt {
+                if I::cursor_location(&before.cursor().inner) >= I::cursor_location(&new_alt.pos) {
+                    inp.add_alt_err(&new_alt.pos, new_alt.err);
+                }
             }
-            Err(()) => Err(()),
+            inp.rewind(before);
+        } else {
+            // Can't fail!
+            let new_alt = new_alt.unwrap();
+            inp.add_alt_err(&new_alt.pos, new_alt.err);
         }
+
+        res
     }
 
     go_extra!(O);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3840,6 +3840,27 @@ mod tests {
     }
 
     #[test]
+    fn rewind() {
+        use crate::{DefaultExpected, LabelError};
+
+        let parser = group((just("a"), any(), just("b").or_not()))
+            .rewind()
+            .then(just::<_, _, extra::Err<Rich<_>>>("ac"));
+
+        assert_eq!(
+            parser.parse("ad").into_output_errors(),
+            (
+                None,
+                vec![LabelError::<&str, _>::expected_found(
+                    [DefaultExpected::Token('c'.into())],
+                    Some('d'.into()),
+                    SimpleSpan::new((), 1..2)
+                )]
+            )
+        )
+    }
+
+    #[test]
     fn zero_size_custom_failure() {
         fn my_custom<'src>() -> impl Parser<'src, &'src str, ()> {
             custom(|inp| {


### PR DESCRIPTION
This is a temporary fix that fixes the problem, but loses some of the error information (Which generally does not violate any chumsky principles, it does not guarantee the completeness of errors). 

The best solution would be to keep two `Cursors` inside `Location`, one referring to the current location, as usual, and the second to the last location outside of rewind. This also requires entering a separate marker where this location was. However, this is a major change that requires further discussion.