### PR TITLE
fix: combinators that should rewind only the input also rewind the state (#858)

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -2758,13 +2758,25 @@ where
     #[inline(always)]
     fn go<M: Mode>(&self, inp: &mut InputRef<'src, '_, I, E>) -> PResult<M, O> {
         let before = inp.save();
-        match self.parser.go::<M>(inp) {
-            Ok(out) => {
-                inp.rewind(before);
-                Ok(out)
+        let old_alt = inp.take_alt();
+        let res = self.parser.go::<M>(inp);
+        let new_alt = inp.take_alt();
+
+        inp.errors.alt = old_alt;
+        if res.is_ok() {
+            if let Some(new_alt) = new_alt {
+                if I::cursor_location(&before.cursor().inner) >= I::cursor_location(&new_alt.pos) {
+                    inp.add_alt_err(&new_alt.pos, new_alt.err);
+                }
             }
-            Err(()) => Err(()),
+            inp.rewind(before);
+        } else {
+            // Can't fail!
+            let new_alt = new_alt.unwrap();
+            inp.add_alt_err(&new_alt.pos, new_alt.err);
         }
+
+        res
     }
 
     go_extra!(O);

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -2443,12 +2443,12 @@ where
             Ok(out) => {
                 // A succeeded -- go back to the beginning and try B
                 let after = inp.save();
-                inp.rewind(before);
+                inp.rewind_input(before);
 
                 match self.parser_b.go::<Check>(inp) {
                     Ok(()) => {
                         // B succeeded -- go to the end of A and return its output
-                        inp.rewind(after);
+                        inp.rewind_input(after);
                         Ok(out)
                     }
                     Err(()) => {
@@ -2769,7 +2769,7 @@ where
                     inp.add_alt_err(&new_alt.pos, new_alt.err);
                 }
             }
-            inp.rewind(before);
+            inp.rewind_input(before);
         } else {
             // Can't fail!
             let new_alt = new_alt.unwrap();

--- a/src/input.rs
+++ b/src/input.rs
@@ -1453,6 +1453,15 @@ impl<'src, 'parse, I: Input<'src>, E: ParserExtra<'src, I>> InputRef<'src, 'pars
         self.cursor = checkpoint.cursor.inner;
     }
 
+    #[inline(always)]
+    pub(crate) fn rewind_input(
+        &mut self,
+        checkpoint: Checkpoint<'src, 'parse, I, <E::State as Inspector<'src, I>>::Checkpoint>,
+    ) {
+        self.errors.secondary.truncate(checkpoint.err_count);
+        self.cursor = checkpoint.cursor.inner;
+    }
+
     /// Get a mutable reference to the state associated with the current parse.
     #[inline(always)]
     pub fn state(&mut self) -> &mut E::State {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3840,6 +3840,27 @@ mod tests {
     }
 
     #[test]
+    fn rewind() {
+        use crate::{DefaultExpected, LabelError};
+
+        let parser = group((just("a"), any(), just("b").or_not()))
+            .rewind()
+            .then(just::<_, _, extra::Err<Rich<_>>>("ac"));
+
+        assert_eq!(
+            parser.parse("ad").into_output_errors(),
+            (
+                None,
+                vec![LabelError::<&str, _>::expected_found(
+                    [DefaultExpected::Token('c'.into())],
+                    Some('d'.into()),
+                    SimpleSpan::new((), 1..2)
+                )]
+            )
+        )
+    }
+
+    #[test]
     fn zero_size_custom_failure() {
         fn my_custom<'src>() -> impl Parser<'src, &'src str, ()> {
             custom(|inp| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3910,6 +3910,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn state_rewind() {
+        use crate::{extra::Full, inspector::TruncateState};
+
+        let parser = any::<_, Full<EmptyErr, TruncateState<char>, ()>>()
+            .map_with(|out, extra| {
+                extra.state().0.push(out);
+                extra.state().0.len() - 1
+            })
+            .rewind()
+            .then_ignore(any());
+
+        let mut state = TruncateState::default();
+        let res = parser.parse_with_state("a", &mut state).unwrap();
+        assert_eq!(res, 0);
+        assert_eq!(state.0.as_slice(), ['a']);
+    }
+
     /*
     #[test]
     fn label_sets() {


### PR DESCRIPTION
This PR is based on #844.