### PR TITLE
feat: impl From<ExpectedNumber> for RichPattern

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -58,6 +58,12 @@ where
     go_extra!(O);
 }
 
+impl<'a, T> From<ExpectedNumber> for error::RichPattern<'a, T> {
+    fn from(_: ExpectedNumber) -> Self {
+        error::RichPattern::Label(std::borrow::Cow::Borrowed("number"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Currently it is not possible to use the `number::Number` parsers with the `Rich` error type as `RichPattern` does not implement `From<ExpectedNumber>`.

This PR adds the missing impl in the `number` module so it is appropriatley feature gated.

Not previously possible:
```rust
fn parse_u8<'a>() -> impl Parser<'a, &'a str, u8, extra::Err<Rich<'a, char>>> {
    let u8_num: Number<STANDARD, &'a str, u8, ErrRich<'a>> = number();
    u8_num
}
```