### PR TITLE
relaxed bounds on ParserExtra (only context needs it now)

### DIFF
--- a/src/extra.rs
+++ b/src/extra.rs
@@ -17,19 +17,19 @@ type DefaultCtx = ();
 ///
 /// This trait is sealed and so cannot be implemented by other crates because all uses should instead
 /// go through the types defined in this module.
-pub trait ParserExtra<'a, I>: 'a + Sealed
+pub trait ParserExtra<'a, I>: Sealed
 where
     I: Input<'a>,
 {
     /// Error type to use for the parser. This type must implement [`Error`], and when it fails,
     /// the parser will return a set of this type to describe why the failure occurred.
-    type Error: Error<'a, I> + 'a;
+    type Error: Error<'a, I>;
     /// State type to use for the parser. This is used to provide stateful *output* of the parser,
     /// such as interned identifiers or position-dependent name resolution, however *cannot* influence
     /// the actual progress of the parser - for that, use [`Self::Context`].
     ///
     /// For examples of using this type, see [`Parser::map_with`] or [`Parser::foldl_with`].
-    type State: Inspector<'a, I> + 'a;
+    type State: Inspector<'a, I>;
     /// Context used for parser configuration. This is used to provide context-sensitive parsing of *input*.
     /// Context-sensitive parsing in chumsky is always left-hand sensitive - context for the parse must originate
     /// from an earlier point in the stream than the parser relying on it. This can affect the output of a parser,
@@ -63,8 +63,8 @@ impl<E, S, C> Sealed for Full<E, S, C> {}
 impl<'a, I, E, S, C> ParserExtra<'a, I> for Full<E, S, C>
 where
     I: Input<'a>,
-    E: Error<'a, I> + 'a,
-    S: Inspector<'a, I> + 'a,
+    E: Error<'a, I>,
+    S: Inspector<'a, I>,
     C: 'a,
 {
     type Error = E;

--- a/src/input.rs
+++ b/src/input.rs
@@ -1355,7 +1355,7 @@ impl<'src, 'parse, I: Input<'src>, E: ParserExtra<'src, I>> InputRef<'src, 'pars
     ) -> O
     where
         'parse: 'sub_parse,
-        S: 'src + Inspector<'src, I>,
+        S: Inspector<'src, I>,
     {
         let mut new_inp = InputRef {
             cursor: self.cursor.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2200,7 +2200,7 @@ pub trait Parser<'src, I: Input<'src>, O, E: ParserExtra<'src, I> = extra::Defau
     ///
     fn boxed<'b>(self) -> Boxed<'src, 'b, I, O, E>
     where
-        Self: Sized + 'src + 'b,
+        Self: Sized + 'b,
     {
         Boxed {
             inner: Rc::new(self),
@@ -2822,7 +2822,7 @@ where
 
     fn boxed<'c>(self) -> Boxed<'src, 'c, I, O, E>
     where
-        Self: Sized + 'src + 'c,
+        Self: Sized + 'c,
     {
         // Never double-box parsers
         self

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -231,17 +231,18 @@ pub fn skip_until<S, U, F>(skip: S, until: U, fallback: F) -> SkipUntil<S, U, F>
 ///
 /// A function that generates a fallback output on recovery is also required.
 // TODO: Make this a strategy, add an unclosed_delimiter error
-pub fn nested_delimiters<'src, I, O, E, F, const N: usize>(
+pub fn nested_delimiters<'src, 'parse, I, O, E, F, const N: usize>(
     start: I::Token,
     end: I::Token,
     others: [(I::Token, I::Token); N],
     fallback: F,
-) -> impl Parser<'src, I, O, E> + Clone
+) -> impl Parser<'src, I, O, E> + Clone + 'parse
 where
     I: ValueInput<'src>,
     I::Token: PartialEq + Clone,
-    E: extra::ParserExtra<'src, I>,
-    F: Fn(I::Span) -> O + Clone,
+    E: extra::ParserExtra<'src, I> + 'parse,
+    'src: 'parse,
+    F: Fn(I::Span) -> O + Clone + 'parse,
 {
     // TODO: Does this actually work? TESTS!
     #[allow(clippy::tuple_array_conversions)]


### PR DESCRIPTION
here like we discussed on discord the PR to remove the ``ParserExtra: 'a`` bound!

all tests pass (except the 3 ignored ones)