### PR TITLE
fix(constraints): relax Parser contrains for `Not` and `Padded`

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -2385,7 +2385,7 @@ impl<A: Clone, OA> Clone for Not<A, OA> {
 
 impl<'src, I, E, A, OA> Parser<'src, I, (), E> for Not<A, OA>
 where
-    I: ValueInput<'src>,
+    I: Input<'src>,
     E: ParserExtra<'src, I>,
     A: Parser<'src, I, OA, E>,
 {

--- a/src/text.rs
+++ b/src/text.rs
@@ -194,7 +194,7 @@ pub struct Padded<A> {
 
 impl<'src, I, O, E, A> Parser<'src, I, O, E> for Padded<A>
 where
-    I: ValueInput<'src>,
+    I: Input<'src>,
     E: ParserExtra<'src, I>,
     I::Token: Char,
     A: Parser<'src, I, O, E>,


### PR DESCRIPTION
Both of the parsers required `ValueInput` though neither require it for their implementation.

I couldn't find any documentation about why it's required, and it's not stated either by the type or by the Parser impl why this is the case. This relaxes both constraints to `Input`.