### PR TITLE
fix mistake in documentation for allow_trailing

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -2164,7 +2164,7 @@ where
 
     /// Allow a trailing separator to appear after the last item.
     ///
-    /// Note that if no items are parsed, no leading separator is permitted.
+    /// Note that if no items are parsed, no trailing separator is permitted.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
I think this was likely a copy/paste error. It confused me for a second when I first read it.