### PR TITLE
select! and select_ref!: allow #[cfg()] gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `select!` and `select_ref!` now support cfg attributes.
+
 ### Removed
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3173,10 +3173,10 @@ where
 /// ```
 #[macro_export]
 macro_rules! select {
-    ($($p:pat $(= $extra:ident)? $(if $guard:expr)? $(=> $out:expr)?),+ $(,)?) => ({
+    ($($(#[$attr:meta])? $p:pat $(= $extra:ident)? $(if $guard:expr)? $(=> $out:expr)?),+ $(,)?) => ({
         $crate::primitive::select(
             move |x, extra| match (x, extra) {
-                $(($p $(,$extra)?, ..) $(if $guard)? => ::core::option::Option::Some({ () $(;$out)? })),+,
+                $($(#[$attr])? ($p $(,$extra)?, ..) $(if $guard)? => ::core::option::Option::Some({ () $(;$out)? })),+,
                 _ => ::core::option::Option::None,
             }
         )
@@ -3192,10 +3192,10 @@ macro_rules! select {
 /// Requires that the parser input implements [`BorrowInput`].
 #[macro_export]
 macro_rules! select_ref {
-    ($($p:pat $(= $extra:ident)? $(if $guard:expr)? $(=> $out:expr)?),+ $(,)?) => ({
+    ($($(#[$attr:meta])? $p:pat $(= $extra:ident)? $(if $guard:expr)? $(=> $out:expr)?),+ $(,)?) => ({
         $crate::primitive::select_ref(
             move |x, extra| match (x, extra) {
-                $(($p $(,$extra)?, ..) $(if $guard)? => ::core::option::Option::Some({ () $(;$out)? })),+,
+                 $($(#[$attr])? ($p $(,$extra)?, ..) $(if $guard)? => ::core::option::Option::Some({ () $(;$out)? })),+,
                 _ => ::core::option::Option::None,
             }
         )


### PR DESCRIPTION
This is handy to match some arguments only if a feature is enabled. For example:
```rust
select! {
   'c' => (),
   #[cfg(feature = "uppercase-is-ok")]
   'C' => ()
}
```

I have not found a good place to write a test, where should I write one